### PR TITLE
Add a circle hitbox, use it for the chips in the card-table example

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ function customItem(x, y, width, height) {
 }
 ```
 
-A hitbox can be made from `WAMS.Rectangle` or `WAMS.Polygon2D`.
+A hitbox can be made from `WAMS.Rectangle` or `WAMS.Polygon2D` or `WAMS.Circle`
 
 `WAMS.Polygon2D` accepts an array of points – vertices of the resulting polygon.
 

--- a/examples/card-table.js
+++ b/examples/card-table.js
@@ -8,6 +8,7 @@
 const path = require('path');
 const WAMS = require('..');
 const Rectangle = WAMS.Rectangle;
+const Circle = WAMS.Circle
 const { image } = WAMS.predefined.items;
 
 /*
@@ -78,16 +79,23 @@ function shuffleButton(x, y) {
 }
 
 function chip(chipName, x, y) {
-  const width = 80;
-  const height = 80;
-
-  return image(`Chips/${chipName}.png`, {
+  const radius = 40;
+  return {
     x,
     y,
-    width,
-    height,
+
+    // Radius for x and y too?
+    // Yes: need to offset hitbox (x, y) to center of circle
+    hitbox: new Circle(radius, radius, radius),
+
     allowDrag: true,
-  });
+    type: 'item/image',
+    src: `Chips/${chipName}.png`,
+
+    // Unclear if width/height actually needed: used by WamsImage
+    width: 80,
+    height: 80,
+  };
 }
 
 function spawnChip(chipName, x, y) {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@
 'use strict';
 
 const { CanvasSequence } = require('canvas-sequencer');
-const { colours, Rectangle, Polygon2D } = require('./src/shared.js');
+const { colours, Circle, Rectangle, Polygon2D } = require('./src/shared.js');
 const { Router, Application } = require('./src/server.js');
 const predefined = require('./src/predefined.js');
 
@@ -16,6 +16,7 @@ module.exports = {
   CanvasSequence,
   predefined,
   colours,
+  Circle,
   Rectangle,
   Polygon2D,
   Router,

--- a/src/predefined/items.js
+++ b/src/predefined/items.js
@@ -8,7 +8,7 @@
 'use strict';
 
 const { CanvasSequence } = require('canvas-sequencer');
-const { Polygon2D, Rectangle } = require('../shared.js');
+const { Circle, Polygon2D, Rectangle } = require('../shared.js');
 
 /**
  * Factories for predefined items.
@@ -83,6 +83,33 @@ function rectangle(x, y, width, height, colour = 'blue', properties = {}) {
  */
 function square(x, y, length, colour = 'red', properties = {}) {
   return rectangle(x, y, length, length, colour, properties);
+}
+
+/**
+ * Generate a circle item.
+ *
+ * @memberof module:predefined.items
+ *
+ * @param {number} x
+ * @param {number} y
+ * @param {number} radius
+ * @param {string} [colour='yellow'] - Fill colour for the circle.
+ * @param {Object} properties - Location and orientation options for the item.
+ * See {@link module:shared.Item} members for available parameters.
+ *
+ * @returns {Object} An object with the parameters for a circle item with the
+ * given radius, filled in with the given colour.
+ */
+function circle(x, y, radius, colour = 'yellow', properties = {}) {
+  const hitbox = new Circle(radius, x, y);
+  const sequence = new CanvasSequence();
+  sequence.fillStyle = colour;
+  sequence.beginPath();
+  sequence.arc(0, 0, radius, 0, 2 * Math.PI);
+  sequence.fill();
+  const type = 'item';
+
+  return { ...properties, x, y, hitbox, sequence, type };
 }
 
 /**
@@ -170,6 +197,7 @@ function html(html, width, height, properties = {}) {
 }
 
 module.exports = {
+  circle,
   element,
   image,
   polygon,

--- a/src/shared.js
+++ b/src/shared.js
@@ -29,6 +29,7 @@ const Utils = require('./shared/utilities.js');
 const Polygon2D = require('./shared/Polygon2D.js');
 const Point2D = require('./shared/Point2D.js');
 const Rectangle = require('./shared/Rectangle.js');
+const Circle = require('./shared/Circle.js');
 
 /**
  * This object stores a set of core constants for use by both the client and
@@ -77,6 +78,7 @@ const colours = [
 module.exports = Object.freeze({
   colours,
   constants,
+  Circle,
   IdStamper,
   Message,
   Point2D,

--- a/src/shared/Circle.js
+++ b/src/shared/Circle.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/**
+ * A simple circular hitbox. Remember that this circle describes the item as if
+ * its settings were x=0, y=0, scale=1, rotation=0.
+ *
+ * @memberof module:shared
+ * @implements {module:shared.Hitbox}
+ *
+ * @param {number} radius - The radius of the circle.
+ * @param {number} [x=0] - The x offset of the circle.
+ * @param {number} [y=0] - The y offset of the circle.
+ */
+class Circle {
+  constructor(radius, x = 0, y = 0) {
+    /**
+     * The radius of the circle.
+     *
+     * @type {number}
+     */
+    this.radius = radius;
+
+    /**
+     * The x coordinate of the circle.
+     *
+     * @type {number}
+     */
+    this.x = x;
+
+    /**
+     * The y coordinate of the circle.
+     *
+     * @type {number}
+     */
+    this.y = y;
+  }
+
+  /**
+   * Determines if a point is inside the circle.
+   *
+   * @param {module:shared.Point2D} point - The point to test.
+   *
+   * @return {boolean} true if the point is inside the circle, false
+   * otherwise.
+   */
+  contains(point) {
+    const distance = Math.sqrt(
+      Math.pow(point.x - this.x, 2) + Math.pow(point.y - this.y, 2)
+    );
+    return distance <= this.radius;
+  }
+}
+
+module.exports = Circle;

--- a/tests/shared.test.js
+++ b/tests/shared.test.js
@@ -13,7 +13,7 @@ const WamsShared = require('shared.js');
 const reporters = Object.keys(require('shared/Reporters.js'));
 const utilities = Object.keys(require('shared/utilities.js'));
 
-const other = ['colours', 'constants', 'IdStamper', 'Message', 'Polygon2D', 'Point2D', 'Rectangle'];
+const other = ['colours', 'Circle', 'constants', 'IdStamper', 'Message', 'Polygon2D', 'Point2D', 'Rectangle'];
 
 const expected = reporters.concat(utilities).concat(other);
 


### PR DESCRIPTION
Relatively quick proof-of-concept for how to add new hitbox shapes.

Lessons learned:
- Should probably rip up the "Reporters" scheme, have decoupled "Serializers" instead. There's a tonne of indirection here, it's probably unnecessary.
- Do we want a "hitboxes.js" module?
- Could also allow direct creation and subclassing of WAMS objects? It's a bit weird to define the properties of an image in an object then hope that WAMS works everything out.
- Keeping track of the different meanings of the "x" and "y" variables everywhere can be hard. Not sure if there's a better naming scheme though. Frames of reference are confusing! (e.g. having to specify x=radius, y=radius for the circle so the hitbox is in the right place).
  - On that note, don't trust the `circle` in the predefined items. Hitbox works though.

Closes #7 