### PR TITLE
Fix up ondrag callback

### DIFF
--- a/examples/swipe-drawing.js
+++ b/examples/swipe-drawing.js
@@ -8,20 +8,38 @@
 const WAMS = require('..');
 const app = new WAMS.Application();
 
-// Executed every time a user swipes the screen.
+/*
+ * Draw a thick line in the direction of the swipe, whose length is its
+ * velocity, with a colour that is selected by the velocity % 10.
+ */
 function handleSwipe({ x, y, velocity, direction }) {
   const cidx = Math.ceil(velocity * 10) % WAMS.colours.length;
+  console.count('swipes');
+  console.dir({ msg: 'Swipe registered', x, y, velocity, direction });
   app.spawn(
-    WAMS.predefined.items.rectangle(x, y, velocity * 10, 32, WAMS.colours[cidx], {
-      type: 'colour',
+    WAMS.predefined.items.rectangle(x, y, velocity * 25, 32, WAMS.colours[cidx], {
       rotation: -direction,
     })
   );
 }
 
+/*
+ * Draw a thin line connecting every drag.
+ */
+function handleDrag({ x, y, dx, dy }) {
+  const length = Math.sqrt(dx * dx + dy * dy);
+  const line = app.spawn(
+    WAMS.predefined.items.rectangle(x, y, 10, length, 'gray', {
+      rotation: Math.atan2(dx, dy),
+    })
+  );
+  console.log('Line: { x: %s, y: %s, length: %s, rotation: %s }', line.x, line.y, length, line.rotation);
+  setTimeout(() => app.removeItem(line), 3000);
+}
+
 function handleConnect(view) {
   view.onswipe = handleSwipe;
-  view.ondrag = handleSwipe;
+  view.ondrag = handleDrag;
 }
 
 app.onconnect(handleConnect);

--- a/src/mixins/Hittable.js
+++ b/src/mixins/Hittable.js
@@ -51,15 +51,20 @@ const Interactable = require('./Interactable.js');
  */
 const Hittable = (sclass) =>
   class Hittable extends Interactable(sclass) {
-    /**
-     * The hitbox for this Hittable instance. If it is null, hit detection will
-     * always return a falsy value.
-     *
-     * @name hitbox
-     * @type {?module:shared.Hitbox}
-     * @default undefined
-     * @memberof module:mixins.Hittable
-     */
+    constructor(...args) {
+      super(...args);
+
+      /**
+       * The hitbox for this Hittable instance. If it is null, hit detection will
+       * always return a falsy value.
+       *
+       * @name hitbox
+       * @type {?module:shared.Hitbox}
+       * @default undefined
+       * @memberof module:mixins.Hittable
+       */
+      this.hitbox = undefined;
+    }
 
     /**
      * Checks whether a point with the given x,y coordinates is contained by

--- a/src/mixins/Interactable.js
+++ b/src/mixins/Interactable.js
@@ -6,9 +6,9 @@
 
 'use strict';
 
-const Lock = require('./Lockable.js');
-const Publish = require('./Publishable.js');
-const Transform = require('./Transformable2D.js');
+const Lockable = require('./Lockable.js');
+const Publishable = require('./Publishable.js');
+const Transformable2D = require('./Transformable2D.js');
 
 /**
  * This mixin combines the Transformable2D, Lockable, and Publishable mixins to
@@ -22,7 +22,7 @@ const Transform = require('./Transformable2D.js');
  * @mixes module:mixins.Transformable2D
  */
 const Interactable = (superclass) => {
-  return class Interactable extends Publish(Lock(Transform(superclass))) {
+  return class Interactable extends Publishable(Lockable(Transformable2D(superclass))) {
     /*
      * Move the transformable by the given amounts.
      *

--- a/src/server/MessageHandler.js
+++ b/src/server/MessageHandler.js
@@ -190,11 +190,9 @@ class MessageHandler {
   shouldDoGesture(handler, event) {
     switch (typeof handler) {
       case 'function':
-        if (handler(event) === true) return true;
-        return false;
+        return handler(event);
       case 'boolean':
-        if (handler === true) return true;
-        return false;
+        return handler;
       default:
         return false;
     }

--- a/src/server/MessageHandler.js
+++ b/src/server/MessageHandler.js
@@ -148,7 +148,7 @@ class MessageHandler {
    * @param {module:shared.Point2D} change
    */
   drag(event, { translation }) {
-    const doGesture = this.shouldDoGesture(event.target.allowDrag, event);
+    const doGesture = this.shouldDoGesture(event.target.allowDrag, event) || event.target.ondrag;
     if (doGesture) {
       const d = event.view.transformPointChange(translation.x, translation.y);
       const dragCallback = event.target.ondrag || actions.drag;

--- a/src/server/MessageHandler.js
+++ b/src/server/MessageHandler.js
@@ -151,22 +151,12 @@ class MessageHandler {
     const doGesture = this.shouldDoGesture(event.target.allowDrag, event);
     if (doGesture) {
       const d = event.view.transformPointChange(translation.x, translation.y);
-      if (event.target.ondrag) {
-        event.target.ondrag(
-          {
-            ...event,
-            dx: d.x,
-            dy: d.y,
-          },
-          this.workspace
-        );
-      } else {
-        actions.drag({
-          ...event,
-          dx: d.x,
-          dy: d.y,
-        });
-      }
+      const dragCallback = event.target.ondrag || actions.drag;
+      dragCallback({
+        ...event,
+        dx: d.x,
+        dy: d.y,
+      });
     }
   }
 

--- a/src/server/ServerGroup.js
+++ b/src/server/ServerGroup.js
@@ -63,11 +63,9 @@ class ServerGroup extends Identifiable(Hittable(Item)) {
   shouldDoGesture(handler) {
     switch (typeof handler) {
       case 'function':
-        if (handler() === true) return true;
-        return false;
+        return handler(event);
       case 'boolean':
-        if (handler === true) return true;
-        return false;
+        return handler;
       default:
         return false;
     }

--- a/src/server/ServerItem.js
+++ b/src/server/ServerItem.js
@@ -38,6 +38,14 @@ class ServerItem extends Identifiable(Hittable(Item)) {
      */
     this.namespace = namespace;
 
+    /**
+     * Sequence of canvas instructions to be run on the client
+     *
+     * @type {CanvasSequence}
+     * @default undefined
+     */
+    this.sequence = undefined;
+
     // Notify subscribers immediately.
     new Message(Message.ADD_ITEM, this).emitWith(this.namespace);
     if (values.sequence) {

--- a/src/server/ServerViewGroup.js
+++ b/src/server/ServerViewGroup.js
@@ -21,8 +21,9 @@ const { Lockable, Transformable2D, Locker } = require('../mixins.js');
  *
  * @memberof module:server
  * @extends module:server.View
- * @mixes module:mixins.Interactable
  * @mixes module:mixins.Locker
+ * @mixes module:mixins.Lockable
+ * @mixes module:mixins.Transformable2D
  *
  * @param {module:server.MessageHandler} messageHandler - For responding to
  * messages from clients.


### PR DESCRIPTION
This follows the plumbing for existing `onX` callbacks, of which it turns out there a few, and does a bit of cleanup. It enables the `ondrag` callback by considering it when determining whether to do drags.

I've updated the `swipe-drawing` example accordingly.

Lessons learned / questions:
- The traceback for Point2D that we're seeing deterministically happens when a client disconnects.
- Something is up with the documentation creation process, it's not creating docs in the same folder as before, so the new docs end up in a different directory. This might be fine, they seem to be okay except for some double reporting of some methods and properties.
- Where are the lint rules defined? Are we just using defaults? Can we impose a line length limit?
- The existing `allowX` for drag etc is a bit of a kludge. I seem to recall rapidly throwing this together, and we should really rip this logic out and just use `onX` / `addEventHandler('X')`. More to come...
- Can do a reasonable line with just the existing tools, since a line is just a rectangle, in a sense.
- How do we want to include the `onX` callbacks in a way where they are discoverable / documented? They're bolted in right now and not documented at all, except in the readme.

Closes #8 