### PR TITLE
Use an EventTarget interface/mixin for the Application, Views, and Items

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ function handleConnect(view, device) {
   linelayout(view, device);
 }
 
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(3500);
 ```
 
@@ -410,12 +410,12 @@ The stylesheets will be automatically loaded by the browsers.
 
 ### Connections
 
-WAMS manages all connections under the hood, and provides helpful methods to react on **connection-related events**:
+WAMS manages all connections under the hood, and provides helpful ways to react on **connection-related events**:
 
 - `onconnect` – called each time a screen connects to a WAMS application
 - `ondisconnect` – called when a screen disconnects
 
-Both methods accept a callback function, where you can act on the event. The callback function gets an event object with these properties:
+Both properties can be assigned a callback function, where you can act on the event. The callback function gets an event object with these properties:
 
 1. `view`
 2. `device`
@@ -468,7 +468,7 @@ function handleLayout(view) {
   setTableLayout(view);
 }
 
-app.onconnect(handleLayout);
+app.onconnect = handleLayout;
 ```
 
 To see this layout in action, check out the `card-table.js` example.
@@ -490,7 +490,7 @@ function handleLayout(view, device) {
   setLineLayout(view, device);
 }
 
-app.onconnect(handleLayout);
+app.onconnect = handleLayout;
 ```
 
 To see this layout in action with multi-screen gestures, check out the `shared-polygons.js` example.

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ WAMS manages all connections under the hood, and provides helpful methods to rea
 - `onconnect` – called each time a screen connects to a WAMS application
 - `ondisconnect` – called when a screen disconnects
 
-Both methods accept a callback function, where you can act on the event. The callback function gets these arguments:
+Both methods accept a callback function, where you can act on the event. The callback function gets an event object with these properties:
 
 1. `view`
 2. `device`

--- a/examples/card-table.js
+++ b/examples/card-table.js
@@ -197,7 +197,7 @@ function handleConnect({ view, device }) {
   tableLayout(view, device);
 }
 
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(9700);
 
 /**

--- a/examples/card-table.js
+++ b/examples/card-table.js
@@ -193,7 +193,7 @@ function flipCard(event) {
 }
 
 const tableLayout = WAMS.predefined.layouts.table(20);
-function handleConnect(view, device) {
+function handleConnect({ view, device }) {
   tableLayout(view, device);
 }
 

--- a/examples/checkers.js
+++ b/examples/checkers.js
@@ -112,5 +112,5 @@ function handleConnect({ view }) {
   view.onrotate = WAMS.predefined.actions.rotate;
 }
 
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(9012);

--- a/examples/checkers.js
+++ b/examples/checkers.js
@@ -100,7 +100,7 @@ function centerViewNormal(view) {
   );
 }
 
-function handleConnect(view) {
+function handleConnect({ view }) {
   if (view.index === 1) {
     view.rotateBy(Math.PI);
   }

--- a/examples/checkers.js
+++ b/examples/checkers.js
@@ -42,7 +42,7 @@ for (let i = 0; i < 10; i += 1) {
 const TOTAL_BOARD_LENGTH = SQUARE_LENGTH * 10;
 
 function handleTokenDrag(event, tokenOwnerIdx) {
-  if (event.view.index !== tokenOwnerIdx) {
+  if (event.view.index === tokenOwnerIdx) {
     WAMS.predefined.actions.drag(event);
   }
 }

--- a/examples/checkers.js
+++ b/examples/checkers.js
@@ -48,33 +48,21 @@ function handleTokenDrag(event, tokenOwnerIdx) {
 }
 
 function spawnToken(x, y, userIdx, properties = {}) {
-  let imgUrl = null;
-  let type = null;
-  if (userIdx === 0) {
-    imgUrl = 'Green_border.png';
-    type = 'green-token';
-  } else if (userIdx === 1) {
-    imgUrl = 'Blue_border.png';
-    type = 'blue-token';
-  }
+  let imgUrl = userIdx === 0 ? 'Green_border.png' : 'Blue_border.png';
 
-  app.spawn(
-    WAMS.predefined.items.html(
-      `<div><img src="${imgUrl}" width="${SQUARE_LENGTH}" height="${SQUARE_LENGTH}" /></div>`,
-      SQUARE_LENGTH,
-      SQUARE_LENGTH,
-      {
-        x,
-        y,
-        width: SQUARE_LENGTH,
-        height: SQUARE_LENGTH,
-        type,
-        ownerIdx: userIdx,
-        ondrag: (e) => handleTokenDrag(e, userIdx),
-        ...properties,
-      }
-    )
-  );
+  const radius = SQUARE_LENGTH / 2;
+  app.spawn({
+    x,
+    y,
+    width: SQUARE_LENGTH,
+    height: SQUARE_LENGTH,
+    hitbox: new WAMS.Circle(radius, radius, radius),
+    type: 'item/image',
+    src: imgUrl,
+    ownerIdx: userIdx,
+    ondrag: (e) => handleTokenDrag(e, userIdx),
+    ...properties,
+  });
 }
 
 for (let i = 0; i < 10; i += 1) {
@@ -112,5 +100,5 @@ function handleConnect({ view }) {
   view.onrotate = WAMS.predefined.actions.rotate;
 }
 
-app.onconnect = handleConnect;
+app.addEventListener('connect', handleConnect);
 app.listen(9012);

--- a/examples/chess.js
+++ b/examples/chess.js
@@ -161,7 +161,7 @@ function centerViewNormal(view) {
 }
 
 /* Function to place board at center of the device view */
-function handleConnect(view) {
+function handleConnect({ view }) {
   if (view.index === 1) {
     view.rotateBy(Math.PI);
   }

--- a/examples/chess.js
+++ b/examples/chess.js
@@ -173,5 +173,5 @@ function handleConnect({ view }) {
   view.onrotate = WAMS.predefined.actions.rotate;
 }
 
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(4000);

--- a/examples/client/drawing-app.js
+++ b/examples/client/drawing-app.js
@@ -46,7 +46,7 @@ class DrawingApp {
       button.classList.add('active');
 
       const type = button.dataset.type;
-      WAMS.dispatch('set-control', type);
+      WAMS.dispatch('set-control', { type });
     }
 
     addClickTouchListener(panBtn, (event) => {
@@ -73,7 +73,7 @@ class DrawingApp {
         colorPicker.classList.remove('show');
         colorBtn.classList = '';
         colorBtn.classList.add(color);
-        WAMS.dispatch('set-color', color);
+        WAMS.dispatch('set-color', { color });
       });
     });
 
@@ -81,7 +81,7 @@ class DrawingApp {
       addClickTouchListener(el, (event) => {
         const width = event.target.dataset.widthname;
         widthPicker.classList.remove('show');
-        WAMS.dispatch('set-width', width);
+        WAMS.dispatch('set-width', { width });
       });
     });
   }

--- a/examples/client/video-player.js
+++ b/examples/client/video-player.js
@@ -45,8 +45,8 @@ WAMS.on('initVideo', () => {
       },
     });
     setInterval(() => {
-      WAMS.dispatch('video-time-sync', Math.floor(window.player.getCurrentTime()));
       window.controls.lastCurrentTime = Math.floor(window.player.getCurrentTime());
+      WAMS.dispatch('video-time-sync', { currentVideoTime: window.controls.lastCurrentTime });
     }, 1000);
   } else {
     setTimeout(() => document.dispatchEvent(new CustomEvent('initVideo')), 100);
@@ -84,7 +84,7 @@ function handlePlayerStateChange({ data }) {
   //    -1         0        1         2         3           5
   // unstarted   ended   playing   paused   buffering   video cued
   const playing = data !== 2 && data !== 5;
-  WAMS.dispatch('play/pause', playing);
+  WAMS.dispatch('play/pause', { playing });
 }
 
 function updateTime({ detail }) {
@@ -103,13 +103,13 @@ function handleReplay() {
   let newTime = Math.floor(window.controls.lastCurrentTime) - 10;
   if (Math.sign(newTime) === -1) newTime = 0;
 
-  WAMS.dispatch('video-time-sync', newTime);
+  WAMS.dispatch('video-time-sync', { currentVideoTime: newTime });
 }
 
 function handleForward() {
   WAMS.dispatch('forward');
   const newTime = Math.floor(window.controls.lastCurrentTime) + 10;
-  WAMS.dispatch('video-time-sync', newTime);
+  WAMS.dispatch('video-time-sync', { currentVideoTime: newTime });
 }
 
 function secondsToMinSecs(totalSeconds) {

--- a/examples/confetti-custom-event.js
+++ b/examples/confetti-custom-event.js
@@ -50,28 +50,23 @@ function handleConnect(view) {
   // view.onclick = spawnSquare;
 }
 
-app.on('mousedown', (event, view) => {
+app.on('mousedown', (event) => {
   const item = app.workspace.findItemByCoordinates(event.x, event.y);
   if (item) {
     event.x = item.x;
     event.y = item.y;
     app.workspace.removeItem(item);
   }
-
-  event.view = view;
   spawnSquare(event, '#FFBF00');
 });
 
-app.on('mouseup', (event, view) => {
+app.on('mouseup', (event) => {
   const item = app.workspace.findItemByCoordinates(event.x, event.y);
-
   if (item) {
     event.x = item.x;
     event.y = item.y;
     app.workspace.removeItem(item);
   }
-
-  event.view = view;
   spawnSquare(event);
 });
 app.onconnect(handleConnect);

--- a/examples/confetti-custom-event.js
+++ b/examples/confetti-custom-event.js
@@ -43,7 +43,7 @@ function spawnSquare(event, color) {
   else app.spawn(square(event.x, event.y, event.view, color));
 }
 
-function handleConnect(view) {
+function handleConnect({ view }) {
   view.onpinch = WAMS.predefined.actions.pinch;
   view.ondrag = WAMS.predefined.actions.drag;
   view.onrotate = WAMS.predefined.actions.rotate;

--- a/examples/confetti-custom-event.js
+++ b/examples/confetti-custom-event.js
@@ -69,5 +69,5 @@ app.on('mouseup', (event) => {
   }
   spawnSquare(event);
 });
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(9013);

--- a/examples/confetti.js
+++ b/examples/confetti.js
@@ -31,7 +31,7 @@ function spawnSquare(event) {
   app.spawn(square(event.x, event.y, event.view));
 }
 
-function handleConnect(view) {
+function handleConnect({ view }) {
   view.onpinch = WAMS.predefined.actions.pinch;
   view.ondrag = WAMS.predefined.actions.drag;
   view.onrotate = WAMS.predefined.actions.rotate;

--- a/examples/confetti.js
+++ b/examples/confetti.js
@@ -38,5 +38,5 @@ function handleConnect({ view }) {
   view.onclick = spawnSquare;
 }
 
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(9013);

--- a/examples/dollar_sign_and_paper.js
+++ b/examples/dollar_sign_and_paper.js
@@ -22,5 +22,5 @@ function handleConnect({ view }) {
   view.ondrag = WAMS.predefined.actions.drag;
   view.onrotate = WAMS.predefined.actions.rotate;
 }
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(9013);

--- a/examples/dollar_sign_and_paper.js
+++ b/examples/dollar_sign_and_paper.js
@@ -17,7 +17,7 @@ const app = new WAMS.Application({
   staticDir: path.join(__dirname, './client'),
 });
 
-function handleConnect(view) {
+function handleConnect({ view }) {
   view.onpinch = WAMS.predefined.actions.pinch;
   view.ondrag = WAMS.predefined.actions.drag;
   view.onrotate = WAMS.predefined.actions.rotate;

--- a/examples/drawing-app.js
+++ b/examples/drawing-app.js
@@ -90,7 +90,7 @@ class DrawingApp {
     view.ondrag = type === 'pan' ? actions.drag : this.draw.bind(this);
   }
 
-  handleConnect(view) {
+  handleConnect({ view }) {
     view.ondrag = WAMS.predefined.actions.drag;
     view.onpinch = WAMS.predefined.actions.zoom;
   }

--- a/examples/drawing-app.js
+++ b/examples/drawing-app.js
@@ -7,6 +7,8 @@
 const WAMS = require('..');
 const path = require('path');
 const { actions } = WAMS.predefined;
+const { CanvasSequence } = require('canvas-sequencer');
+
 
 const COLORS = {
   red: '#D12C1F',
@@ -67,12 +69,34 @@ class DrawingApp {
     });
 
     this.app.onconnect(this.handleConnect.bind(this));
-    this.app.listen(8080);
+    this.app.listen(3000);
+  }
+
+  draw(event) {
+    const color = event.view.state.color || 'black';
+    const width = event.view.state.width || 20;
+    // const fromX = event.x - event.dx;
+    // const fromY = event.y - event.dy;
+    const toX = event.x;
+    const toY = event.y;
+    console.log('draw', color, width, toX, toY);
+    const line = new CanvasSequence();
+    // line.beginPath()
+    // line.moveTo(fromX, fromY);
+    // line.lineTo(toX, toY);
+    // line.strokeStyle = 'blue';
+    // line.stroke();
+
+    line.beginPath();
+    line.fillStyle = color;
+    line.ellipse(toX, toY, width / 2, width / 2, Math.PI / 2, 0, 2 * Math.PI);
+    line.fill();
+    this.app.workspace.spawnItem({ sequence: line });
   }
 
   updateControlType(type, view) {
     this.controlType = type;
-    view.ondrag = type === 'pan' ? actions.drag : actions.draw;
+    view.ondrag = type === 'pan' ? actions.drag : this.draw.bind(this);
   }
 
   handleConnect(view) {

--- a/examples/drawing-app.js
+++ b/examples/drawing-app.js
@@ -9,7 +9,6 @@ const path = require('path');
 const { actions } = WAMS.predefined;
 const { CanvasSequence } = require('canvas-sequencer');
 
-
 const COLORS = {
   red: '#D12C1F',
   orange: '#EF9135',

--- a/examples/drawing-app.js
+++ b/examples/drawing-app.js
@@ -41,33 +41,24 @@ class DrawingApp {
     this.initListeners();
   }
 
-  setColor(color, view) {
+  setColor({ color, view }) {
     view.state.color = COLORS[color];
   }
 
-  setWidth(width, view) {
+  setWidth({ width, view }) {
     view.state.width = WIDTHS[width];
   }
 
   initListeners() {
-    this.app.on('init', (data, view) => {
+    this.app.on('init', ({ view }) => {
       const color = this.initialColor;
-      this.setColor(color, view);
+      this.setColor({ color, view });
       view.dispatch('render-controls', { color, listOfColors: COLORS, listOfWidths: WIDTHS });
     });
 
-    this.app.on('set-control', (type, view) => {
-      this.updateControlType(type, view);
-    });
-
-    this.app.on('set-color', (color, view) => {
-      this.setColor(color, view);
-    });
-
-    this.app.on('set-width', (width, view) => {
-      this.setWidth(width, view);
-    });
-
+    this.app.on('set-control', this.updateControlType.bind(this));
+    this.app.on('set-color', this.setColor.bind(this));
+    this.app.on('set-width', this.setWidth.bind(this));
     this.app.onconnect(this.handleConnect.bind(this));
     this.app.listen(3000);
   }
@@ -94,7 +85,7 @@ class DrawingApp {
     this.app.workspace.spawnItem({ sequence: line });
   }
 
-  updateControlType(type, view) {
+  updateControlType({ type, view }) {
     this.controlType = type;
     view.ondrag = type === 'pan' ? actions.drag : this.draw.bind(this);
   }

--- a/examples/drawing-app.js
+++ b/examples/drawing-app.js
@@ -58,7 +58,7 @@ class DrawingApp {
     this.app.on('set-control', this.updateControlType.bind(this));
     this.app.on('set-color', this.setColor.bind(this));
     this.app.on('set-width', this.setWidth.bind(this));
-    this.app.onconnect(this.handleConnect.bind(this));
+    this.app.onconnect = this.handleConnect.bind(this);
     this.app.listen(3000);
   }
 

--- a/examples/elements.js
+++ b/examples/elements.js
@@ -39,5 +39,5 @@ function handleConnect({ view }) {
   view.onclick = spawnElement;
 }
 
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(9002);

--- a/examples/elements.js
+++ b/examples/elements.js
@@ -32,7 +32,7 @@ function spawnElement(event) {
   app.spawn(element(event.x, event.y, event.view));
 }
 
-function handleConnect(view) {
+function handleConnect({ view }) {
   view.onpinch = WAMS.predefined.actions.pinch;
   view.ondrag = WAMS.predefined.actions.drag;
   view.onrotate = WAMS.predefined.actions.rotate;

--- a/examples/jumbotron.js
+++ b/examples/jumbotron.js
@@ -33,7 +33,7 @@ app.spawn(
 
 const jumbotronLayout = jumbotron(1200 * scale);
 
-function handleConnect(view) {
+function handleConnect({ view }) {
   jumbotronLayout(view);
 }
 

--- a/examples/jumbotron.js
+++ b/examples/jumbotron.js
@@ -37,7 +37,7 @@ function handleConnect({ view }) {
   jumbotronLayout(view);
 }
 
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(9010);
 
 /**

--- a/examples/photo-lens.js
+++ b/examples/photo-lens.js
@@ -24,7 +24,7 @@ app.spawn(
   })
 );
 
-function handleConnect(view) {
+function handleConnect({ view }) {
   view.onrotate = WAMS.predefined.actions.rotate;
   if (view.index > 0) {
     view.scale = 2.5;

--- a/examples/photo-lens.js
+++ b/examples/photo-lens.js
@@ -33,5 +33,5 @@ function handleConnect({ view }) {
   }
 }
 
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(9011);

--- a/examples/pick-n-drop.js
+++ b/examples/pick-n-drop.js
@@ -41,7 +41,7 @@ function handleConnect({ view, device, group }) {
   dimensions[view.index] = { x: device.x, y: device.y, width: device.width, height: device.height };
 }
 
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(9700);
 
 function moveScreenToScreen(currentView, targetView) {

--- a/examples/pick-n-drop.js
+++ b/examples/pick-n-drop.js
@@ -31,7 +31,7 @@ app.on('deviceFarFromScreens', (data) => {
 });
 
 const setLayout = line(0);
-function handleConnect(view, device, group) {
+function handleConnect({ view, device, group }) {
   if (view.index >= 2) {
     // send to deep space :)
     view.moveTo(deepSpace.x, deepSpace.y);

--- a/examples/polygons.js
+++ b/examples/polygons.js
@@ -33,7 +33,7 @@ function spawnItem(event) {
   app.spawn(polygon(event.x, event.y, event.view));
 }
 
-function handleConnect(view) {
+function handleConnect({ view }) {
   view.onclick = spawnItem;
   view.onpinch = WAMS.predefined.actions.pinch;
   view.onrotate = WAMS.predefined.actions.rotate;

--- a/examples/polygons.js
+++ b/examples/polygons.js
@@ -40,5 +40,5 @@ function handleConnect({ view }) {
   view.ondrag = WAMS.predefined.actions.drag;
 }
 
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(9014);

--- a/examples/projected.js
+++ b/examples/projected.js
@@ -33,7 +33,7 @@ app.spawn(
   })
 );
 
-function viewSetup(view, device, group) {
+function viewSetup({ view, device, group }) {
   if (view.index === 0) {
     view.scaleBy(0.6);
   } else if (view.index === 1) {

--- a/examples/projected.js
+++ b/examples/projected.js
@@ -46,5 +46,5 @@ function viewSetup({ view, device, group }) {
   }
 }
 
-app.onconnect(viewSetup);
+app.onconnect = viewSetup;
 app.listen(3500);

--- a/examples/scaffold.js
+++ b/examples/scaffold.js
@@ -3,6 +3,6 @@
 const WAMS = require('..');
 const app = new WAMS.Application();
 
-app.onconnect((view) => {});
+app.onconnect(({ view }) => {});
 
 app.listen(8080);

--- a/examples/scaffold.js
+++ b/examples/scaffold.js
@@ -3,6 +3,6 @@
 const WAMS = require('..');
 const app = new WAMS.Application();
 
-app.onconnect(({ view }) => {});
+app.onconnect = ({ view }) => {};
 
 app.listen(8080);

--- a/examples/shared-polygons.js
+++ b/examples/shared-polygons.js
@@ -37,7 +37,7 @@ function spawnItem(event) {
 
 // use predefined "line layout"
 const linelayout = WAMS.predefined.layouts.line(200);
-function handleConnect(view, device, group) {
+function handleConnect({ view, device, group }) {
   group.onclick = spawnItem;
   group.onpinch = WAMS.predefined.actions.pinch;
   group.onrotate = WAMS.predefined.actions.rotate;

--- a/examples/shared-polygons.js
+++ b/examples/shared-polygons.js
@@ -45,5 +45,5 @@ function handleConnect({ view, device, group }) {
   linelayout(view, device);
 }
 
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(9500);

--- a/examples/swipe-drawing.js
+++ b/examples/swipe-drawing.js
@@ -42,5 +42,5 @@ function handleConnect({ view }) {
   view.ondrag = handleDrag;
 }
 
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(9002);

--- a/examples/swipe-drawing.js
+++ b/examples/swipe-drawing.js
@@ -37,7 +37,7 @@ function handleDrag({ x, y, dx, dy }) {
   setTimeout(() => app.removeItem(line), 3000);
 }
 
-function handleConnect(view) {
+function handleConnect({ view }) {
   view.onswipe = handleSwipe;
   view.ondrag = handleDrag;
 }

--- a/examples/video-player.js
+++ b/examples/video-player.js
@@ -50,8 +50,8 @@ class VideoPlayer {
     this.app.on('forward', this.handleForward.bind(this));
     this.app.on('replay', this.handleReplay.bind(this));
     this.app.on('video-time-sync', this.handleVideoTimeSync.bind(this));
-    this.app.onconnect(this.handleConnect.bind(this));
-    this.app.ondisconnect(this.handleDisconnect.bind(this));
+    this.app.onconnect = this.handleConnect.bind(this);
+    this.app.ondisconnect = this.handleDisconnect.bind(this);
     this.app.listen(3000);
   }
 

--- a/examples/video-player.js
+++ b/examples/video-player.js
@@ -118,7 +118,7 @@ class VideoPlayer {
     console.log(this.controls);
   }
 
-  handleConnect(view) {
+  handleConnect({ view }) {
     if (!this.player.mounted) {
       this.spawnPlayerWrapper(view);
     }

--- a/examples/video-player.js
+++ b/examples/video-player.js
@@ -52,10 +52,11 @@ class VideoPlayer {
     this.app.on('video-time-sync', this.handleVideoTimeSync.bind(this));
     this.app.onconnect(this.handleConnect.bind(this));
     this.app.ondisconnect(this.handleDisconnect.bind(this));
-    this.app.listen(8080);
+    this.app.listen(3000);
   }
 
-  handlePlayerStateChange(playing) {
+  handlePlayerStateChange({ playing }) {
+    console.log('handlePlayerStateChange: ', playing);
     if (playing === undefined) {
       this.player.playing = !this.player.playing;
       this.app.dispatch('setPlayingState', { playing: this.player.playing });
@@ -66,7 +67,7 @@ class VideoPlayer {
     }
   }
 
-  handleVideoTimeSync(currentVideoTime) {
+  handleVideoTimeSync({ currentVideoTime }) {
     this.app.dispatch('video-time-sync', currentVideoTime);
   }
 

--- a/examples/video.js
+++ b/examples/video.js
@@ -56,7 +56,7 @@ app.spawn(
   })
 );
 
-function handleConnect(view) {
+function handleConnect({ view }) {
   // allowing the whole view to
   // be moved around, rotated and scaled
   view.onpinch = WAMS.predefined.actions.pinch;

--- a/examples/video.js
+++ b/examples/video.js
@@ -64,5 +64,5 @@ function handleConnect({ view }) {
   view.ondrag = WAMS.predefined.actions.drag;
 }
 
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(9020);

--- a/examples/walkthrough-paper.js
+++ b/examples/walkthrough-paper.js
@@ -20,5 +20,5 @@ function handleConnect({ view, device }) {
   linelayout(view, device);
 }
 
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(3600);

--- a/examples/walkthrough-paper.js
+++ b/examples/walkthrough-paper.js
@@ -15,7 +15,7 @@ function spawnSquare(event) {
 }
 
 const linelayout = line();
-function handleConnect(view, device) {
+function handleConnect({ view, device }) {
   view.onclick = spawnSquare;
   linelayout(view, device);
 }

--- a/examples/webpage-sharing.js
+++ b/examples/webpage-sharing.js
@@ -54,7 +54,7 @@ function setLayout(view) {
   }
 }
 
-function handleConnect(view) {
+function handleConnect({ view }) {
   if (view.index === 0) {
     mainScreen = view;
   }

--- a/examples/webpage-sharing.js
+++ b/examples/webpage-sharing.js
@@ -64,7 +64,7 @@ function handleConnect({ view }) {
   view.onclick = (ev) => spawnIframe(ev, 'http://www.example.com');
 }
 
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(9021);
 
 function handleIframeDrag(event) {

--- a/examples/webpages.js
+++ b/examples/webpages.js
@@ -53,5 +53,5 @@ function handleConnect({ view }) {
   view.ondrag = WAMS.predefined.actions.drag;
 }
 
-app.onconnect(handleConnect);
+app.onconnect = handleConnect;
 app.listen(9021);

--- a/examples/webpages.js
+++ b/examples/webpages.js
@@ -47,7 +47,7 @@ app.spawn(
   })
 );
 
-function handleConnect(view) {
+function handleConnect({ view }) {
   view.onpinch = WAMS.predefined.actions.pinch;
   view.onrotate = WAMS.predefined.actions.rotate;
   view.ondrag = WAMS.predefined.actions.drag;

--- a/src/client.js
+++ b/src/client.js
@@ -42,6 +42,9 @@ function ClientApplication(controller) {
           document.dispatchEvent(new CustomEvent(event, { detail: ev.payload }));
         }
       });
+
+      // Remove events from the queue that have been dispatched.
+      controller.eventQueue = controller.eventQueue.filter((ev) => ev.action !== event);
     },
     dispatch: (event, func) => controller.dispatch(event, func),
   };

--- a/src/client/ClientController.js
+++ b/src/client/ClientController.js
@@ -17,7 +17,7 @@ const Interactor = require('./Interactor.js');
 
 // Symbols to identify these methods as intended only for internal use
 const symbols = Object.freeze({
-  attachListeners: Symbol('attachListeners'),
+  attachSocketIoListeners: Symbol('attachSocketIoListeners'),
   render: Symbol('render'),
 });
 
@@ -121,10 +121,10 @@ class ClientController {
    *
    * This internal routine should be called as part of socket establishment.
    *
-   * @alias [@@attachListeners]
+   * @alias [@@attachSocketIoListeners]
    * @memberof module:client.ClientController
    */
-  [symbols.attachListeners]() {
+  [symbols.attachSocketIoListeners]() {
     const listeners = {
       // For the server to inform about changes to the model
       [Message.ADD_ELEMENT]: (data) => this.handle('addElement', data),
@@ -195,7 +195,7 @@ class ClientController {
       reconnection: false,
       transports: ['websocket', 'polling'],
     });
-    this[symbols.attachListeners]();
+    this[symbols.attachSocketIoListeners]();
     window.requestAnimationFrame(this.render_fn);
     this.socket.connect();
   }

--- a/src/mixins.js
+++ b/src/mixins.js
@@ -1,9 +1,3 @@
-/*
- * WAMS - An API for Multi-Surface Environments
- *
- * Author: Michael van der Kamp
- */
-
 /**
  * Mixins used by the WAMS project.
  *
@@ -26,6 +20,7 @@
 
 'use strict';
 
+const EventTarget = require('./mixins/EventTarget.js');
 const Hittable = require('./mixins/Hittable.js');
 const Identifiable = require('./mixins/Identifiable.js');
 const Interactable = require('./mixins/Interactable.js');
@@ -35,6 +30,7 @@ const Publishable = require('./mixins/Publishable.js');
 const Transformable2D = require('./mixins/Transformable2D.js');
 
 module.exports = {
+  EventTarget,
   Hittable,
   Identifiable,
   Interactable,

--- a/src/mixins/EventTarget.js
+++ b/src/mixins/EventTarget.js
@@ -25,7 +25,7 @@ const EventTarget = (superclass) => class EventTarget extends superclass {
    * @param {string} event name of the event.
    * @param {object} payload argument to pass to the event handler.
    */
-  handleEvent(event, payload) {
+  dispatchEvent(event, payload) {
     const callback_name = `on${event}`;
     if (this[callback_name]) this[callback_name](payload);
     if (this.listeners[event]) this.listeners[event].forEach((listener) => listener(payload));

--- a/src/mixins/EventTarget.js
+++ b/src/mixins/EventTarget.js
@@ -1,61 +1,61 @@
 'use strict';
 
+const EventTarget = (superclass) =>
+  class EventTarget extends superclass {
+    constructor(...args) {
+      super(...args);
 
-const EventTarget = (superclass) => class EventTarget extends superclass {
-  constructor(...args) {
-    super(...args);
+      /**
+       * Event listeners. Maps string events names to arrays of functions.
+       * Functions will be called with two arguments: the event object, and the
+       * view object.
+       *
+       * Handlers can also be connected directly as "onX" properties of the
+       * object, however only one handler can be connected per event type in this
+       * manner.
+       *
+       * @type {object}
+       */
+      this.listeners = {};
+    }
 
     /**
-     * Event listeners. Maps string events names to arrays of functions.
-     * Functions will be called with two arguments: the event object, and the
-     * view object.
+     * Call any listeners and the callback if it exists for the given event.
      *
-     * Handlers can also be connected directly as "onX" properties of the
-     * object, however only one handler can be connected per event type in this
-     * manner.
-     *
-     * @type {object}
+     * @param {string} event name of the event.
+     * @param {object} payload argument to pass to the event handler.
      */
-    this.listeners = {};
-  }
+    dispatchEvent(event, payload) {
+      const callback_name = `on${event}`;
+      if (this[callback_name]) this[callback_name](payload);
+      if (this.listeners[event]) this.listeners[event].forEach((listener) => listener(payload));
+    }
 
-  /**
-   * Call any listeners and the callback if it exists for the given event.
-   *
-   * @param {string} event name of the event.
-   * @param {object} payload argument to pass to the event handler.
-   */
-  dispatchEvent(event, payload) {
-    const callback_name = `on${event}`;
-    if (this[callback_name]) this[callback_name](payload);
-    if (this.listeners[event]) this.listeners[event].forEach((listener) => listener(payload));
-  }
+    /**
+     * Add a listener for the given event.
+     *
+     * @param {string} event name of the event.
+     * @param {function} listener function to call when the event is dispatched.
+     */
+    addEventListener(event, listener) {
+      if (!this.listeners[event]) this.listeners[event] = [];
+      this.listeners[event].push(listener);
+    }
 
-  /**
-   * Add a listener for the given event.
-   *
-   * @param {string} event name of the event.
-   * @param {function} listener function to call when the event is dispatched.
-   */
-  addEventListener(event, listener) {
-    if (!this.listeners[event]) this.listeners[event] = [];
-    this.listeners[event].push(listener);
-  }
+    /**
+     * Remove a listener for the given event.
+     *
+     * @param {string} event name of the event.
+     * @param {function} listener function to call when the event is dispatched.
+     * @returns {boolean} true if the listener was removed, false if it was not
+     */
+    removeEventListener(event, listener) {
+      if (!this.listeners[event]) return false;
+      const index = this.listeners[event].indexOf(listener);
+      if (index === -1) return false;
+      this.listeners[event].splice(index, 1);
+      return true;
+    }
+  };
 
-  /**
-   * Remove a listener for the given event.
-   *
-   * @param {string} event name of the event.
-   * @param {function} listener function to call when the event is dispatched.
-   * @returns {boolean} true if the listener was removed, false if it was not
-   */
-  removeEventListener(event, listener) {
-    if (!this.listeners[event]) return false;
-    const index = this.listeners[event].indexOf(listener);
-    if (index === -1) return false;
-    this.listeners[event].splice(index, 1);
-    return true;
-  }
-}
-
-module.exports = EventTarget
+module.exports = EventTarget;

--- a/src/mixins/EventTarget.js
+++ b/src/mixins/EventTarget.js
@@ -26,7 +26,6 @@ const EventTarget = (superclass) => class EventTarget extends superclass {
    * @param {object} payload argument to pass to the event handler.
    */
   handleEvent(event, payload) {
-    console.debug(`handleEvent: "${event}"`);
     const callback_name = `on${event}`;
     if (this[callback_name]) this[callback_name](payload);
     if (this.listeners[event]) this.listeners[event].forEach((listener) => listener(payload));

--- a/src/mixins/EventTarget.js
+++ b/src/mixins/EventTarget.js
@@ -1,0 +1,62 @@
+'use strict';
+
+
+const EventTarget = (superclass) => class EventTarget extends superclass {
+  constructor(...args) {
+    super(...args);
+
+    /**
+     * Event listeners. Maps string events names to arrays of functions.
+     * Functions will be called with two arguments: the event object, and the
+     * view object.
+     *
+     * Handlers can also be connected directly as "onX" properties of the
+     * object, however only one handler can be connected per event type in this
+     * manner.
+     *
+     * @type {object}
+     */
+    this.listeners = {};
+  }
+
+  /**
+   * Call any listeners and the callback if it exists for the given event.
+   *
+   * @param {string} event name of the event.
+   * @param {object} payload argument to pass to the event handler.
+   */
+  handleEvent(event, payload) {
+    console.debug(`handleEvent: "${event}"`);
+    const callback_name = `on${event}`;
+    if (this[callback_name]) this[callback_name](payload);
+    if (this.listeners[event]) this.listeners[event].forEach((listener) => listener(payload));
+  }
+
+  /**
+   * Add a listener for the given event.
+   *
+   * @param {string} event name of the event.
+   * @param {function} listener function to call when the event is dispatched.
+   */
+  addEventListener(event, listener) {
+    if (!this.listeners[event]) this.listeners[event] = [];
+    this.listeners[event].push(listener);
+  }
+
+  /**
+   * Remove a listener for the given event.
+   *
+   * @param {string} event name of the event.
+   * @param {function} listener function to call when the event is dispatched.
+   * @returns {boolean} true if the listener was removed, false if it was not
+   */
+  removeEventListener(event, listener) {
+    if (!this.listeners[event]) return false;
+    const index = this.listeners[event].indexOf(listener);
+    if (index === -1) return false;
+    this.listeners[event].splice(index, 1);
+    return true;
+  }
+}
+
+module.exports = EventTarget

--- a/src/mixins/Lockable.js
+++ b/src/mixins/Lockable.js
@@ -6,19 +6,23 @@
 
 'use strict';
 
+const EventTarget = require('./EventTarget.js');
+
 const locked = Symbol.for('locked');
 const holder = Symbol.for('holder');
 
 /**
  * The Lockable mixin allows a class to enable itself to be locked and unlocked,
- * with the default being unlocked.
+ * with the default being unlocked. Since locked items can be the targets of
+ * events, (see Workspace.obtainLock and its use) this mixin also extends the
+ * EventTarget mixin.
  *
  * @memberof module:mixins
  *
  * @mixin
  */
 const Lockable = (superclass) =>
-  class Lockable extends superclass {
+  class Lockable extends EventTarget(superclass) {
     /**
      * Whether this Lockable is locked.
      *

--- a/src/mixins/Publishable.js
+++ b/src/mixins/Publishable.js
@@ -64,16 +64,19 @@ const Publishable = (superclass) =>
      */
     [symbols.emit]() {
       this[symbols.scheduled] = false;
-      this.emitPublication();
+      this._emitPublication();
     }
 
     /**
-     * Emit the publication of this object.
+     * Emit the publication of this object. This method must be implemented by
+     * classes that use this mixin. It should never be called except by this
+     * mixin.
      *
+     * @protected
      * @memberof module:mixins.Publishable
      */
-    emitPublication() {
-      throw Error('Classes using Publishable mixin must implement emitPublication()');
+    _emitPublication() {
+      throw Error('Classes using Publishable mixin must implement _emitPublication()');
     }
   };
 

--- a/src/predefined/actions.js
+++ b/src/predefined/actions.js
@@ -7,35 +7,12 @@
 
 'use strict';
 
-const { CanvasSequence } = require('canvas-sequencer');
-
 /**
  * Transformation actions for items.
  *
  * @namespace actions
  * @memberof module:predefined
  */
-
-function draw(event, workspace) {
-  const color = event.view.state.color || 'black';
-  const width = event.view.state.width || 20;
-  // const fromX = event.x - event.dx;
-  // const fromY = event.y - event.dy;
-  const toX = event.x;
-  const toY = event.y;
-  const line = new CanvasSequence();
-  // line.beginPath()
-  // line.moveTo(fromX, fromY);
-  // line.lineTo(toX, toY);
-  // line.strokeStyle = 'blue';
-  // line.stroke();
-
-  line.beginPath();
-  line.fillStyle = color;
-  line.ellipse(toX, toY, width / 2, width / 2, Math.PI / 2, 0, 2 * Math.PI);
-  line.fill();
-  workspace.spawnItem({ sequence: line });
-}
 
 /**
  * Drags the group or target.
@@ -94,7 +71,6 @@ function isView(item) {
 }
 
 module.exports = Object.freeze({
-  draw,
   drag,
   rotate,
   scale,

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -247,7 +247,7 @@ class Application {
   }
 
   /**
-   * Send Message to clients to dispatch user-defined action.
+   * Send Message to all clients to dispatch user-defined action.
    *
    * @param {string} action name of the user-defined action.
    * @param {object} payload argument of the user-defined action function.

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -23,6 +23,7 @@ const TrackingSwitchboard = require('./TrackingSwitchboard.js');
 const WorkSpace = require('./WorkSpace.js');
 const MessageHandler = require('./MessageHandler.js');
 const ServerViewGroup = require('./ServerViewGroup.js');
+const { EventTarget } = require('../mixins.js');
 
 /**
  * @inner
@@ -52,8 +53,10 @@ function getLocalIP() {
  * @param {object} [settings={}] - Settings data to be forwarded to the server.
  * @param {module:server.Router} [router=Router()] - Route handler to use.
  */
-class Application {
-  constructor(settings = {}, router = Router()) {
+class Application extends EventTarget(Object) {
+  constructor(settings = {}, router = Router(), ...args) {
+    super(...args);
+
     this.setupStaticRoute(settings, router);
 
     /**
@@ -100,7 +103,7 @@ class Application {
      *
      * @type {module:server.MessageHandler}
      */
-    this.messageHandler = new MessageHandler(this.workspace);
+    this.messageHandler = new MessageHandler(this, this.workspace);
 
     /**
      * Track the active group.
@@ -155,26 +158,6 @@ class Application {
       console.log(`🔗 ${createAddress(address, port)}`);
       console.log(`🔗 ${createAddress(host, port)}`);
     });
-  }
-
-  /**
-   * Register a layout callback.
-   *
-   * @param {function} callback - Handler to trigger when a user
-   * connects.
-   */
-  onconnect(callback) {
-    this.messageHandler.onconnect = callback;
-  }
-
-  /**
-   * Register a disconnect callback.
-   *
-   * @param {function} callback - Layout handler to trigger when a user
-   * disconnects.
-   */
-  ondisconnect(callback) {
-    this.messageHandler.ondisconnect = callback;
   }
 
   /**
@@ -266,7 +249,7 @@ class Application {
    * @param {*} handler handler of the custom event.
    */
   on(event, handler) {
-    this.messageHandler.addEventListener(event, handler);
+    this.addEventListener(event, handler);
   }
 }
 

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -253,7 +253,10 @@ class Application {
    * @param {object} payload argument of the user-defined action function.
    */
   dispatch(action, payload) {
-    return this.messageHandler.dispatch(action, payload);
+    const dreport = new DataReporter({
+      data: { action, payload },
+    });
+    new Message(Message.DISPATCH, dreport).emitWith(this.workspace.namespace);
   }
 
   /**

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -263,11 +263,7 @@ class Application {
    * @param {*} handler handler of the custom event.
    */
   on(event, handler) {
-    if (this.messageHandler.listeners[event]) {
-      throw Error(`Listener already exists for custom event "${event}"`);
-    }
-
-    this.messageHandler.listeners[event] = handler;
+    this.messageHandler.addEventListener(event, handler);
   }
 }
 

--- a/src/server/MessageHandler.js
+++ b/src/server/MessageHandler.js
@@ -9,6 +9,8 @@
 const { Message, DataReporter } = require('../shared.js');
 const { actions } = require('../predefined');
 
+const EVENTS = Object.freeze(['connect', 'disconnect']);
+
 /**
  * The MessageHandler logs listeners that are attached by the user and receives
  * messages from clients, which it then uses to call the appropriate listener.
@@ -39,6 +41,9 @@ class MessageHandler {
      * @type {object}
      */
     this.listeners = {};
+    EVENTS.forEach((event_name) => {
+      this.listeners[event_name] = [];
+    });
   }
 
   /**

--- a/src/server/MessageHandler.js
+++ b/src/server/MessageHandler.js
@@ -2,7 +2,6 @@
 
 const { Message, DataReporter } = require('../shared.js');
 const { actions } = require('../predefined');
-const { EventTarget } = require('../mixins.js');
 
 const EVENTS = Object.freeze(['connect', 'disconnect']);
 
@@ -15,9 +14,15 @@ const EVENTS = Object.freeze(['connect', 'disconnect']);
  * @param {module:server.WorkSpace} workspace - the model used when responding
  * to messages.
  */
-class MessageHandler extends EventTarget(Object) {
-  constructor(workspace, ...args) {
-    super(...args);
+class MessageHandler {
+  constructor(application, workspace) {
+    /**
+     * The Application to which this MessageHandler belongs.
+     * @type {module:server.Application}
+     * @private
+     * @readonly
+     */
+    this.application = application;
 
     /**
      * The model to access when responding to messages.
@@ -43,6 +48,16 @@ class MessageHandler extends EventTarget(Object) {
       }
     }
     return doGesture.bind(this);
+  }
+
+  /**
+   * Send an event to the application
+   *
+   * @param {string} name
+   * @param {object} data
+   */
+  send(name, data) {
+    this.application.handleEvent(name, data);
   }
 
   /**

--- a/src/server/MessageHandler.js
+++ b/src/server/MessageHandler.js
@@ -57,7 +57,7 @@ class MessageHandler {
    * @param {object} data
    */
   send(name, data) {
-    this.application.handleEvent(name, data);
+    this.application.dispatchEvent(name, data);
   }
 
   /**
@@ -69,10 +69,10 @@ class MessageHandler {
     const { target, x, y } = event;
 
     if (typeof target.containsPoint === 'function' && target.containsPoint(x, y)) {
-      target.handleEvent('click', event);
+      target.dispatchEvent('click', event);
     } else {
       const target = this.workspace.findFreeItemByCoordinates(x, y) || event.view;
-      target.handleEvent('click', { ...event, target });
+      target.dispatchEvent('click', { ...event, target });
     }
   }
 
@@ -126,7 +126,7 @@ class MessageHandler {
    * @param {object} scale
    */
   scale(event, { scale }) {
-    event.target.handleEvent('pinch', { ...event, scale });
+    event.target.dispatchEvent('pinch', { ...event, scale });
   }
 
   /**
@@ -136,7 +136,7 @@ class MessageHandler {
    * @param {object} rotation
    */
   rotate(event, { rotation }) {
-    event.target.handleEvent('rotate', { ...event, rotation });
+    event.target.dispatchEvent('rotate', { ...event, rotation });
   }
 
   /**
@@ -147,7 +147,7 @@ class MessageHandler {
    */
   drag(event, { translation }) {
     const d = event.view.transformPointChange(translation.x, translation.y);
-    event.target.handleEvent('drag', { ...event, dx: d.x, dy: d.y });
+    event.target.dispatchEvent('drag', { ...event, dx: d.x, dy: d.y });
   }
 
   /**
@@ -159,7 +159,7 @@ class MessageHandler {
   swipe(event, data) {
     const { target } = event;
     const { velocity, direction } = data;
-    event.target.handleEvent('swipe', { ...event, velocity, direction });
+    event.target.dispatchEvent('swipe', { ...event, velocity, direction });
   }
 }
 

--- a/src/server/MessageHandler.js
+++ b/src/server/MessageHandler.js
@@ -54,10 +54,10 @@ class MessageHandler extends EventTarget(Object) {
     const { target, x, y } = event;
 
     if (typeof target.containsPoint === 'function' && target.containsPoint(x, y)) {
-      if (target.onclick) target.onclick(event);
+      target.handleEvent('click', event);
     } else {
       const target = this.workspace.findFreeItemByCoordinates(x, y) || event.view;
-      if (target.onclick) target.onclick({ ...event, target });
+      target.handleEvent('click', { ...event, target });
     }
   }
 
@@ -111,7 +111,7 @@ class MessageHandler extends EventTarget(Object) {
    * @param {object} scale
    */
   scale(event, { scale }) {
-    if (event.target.onpinch) event.target.onpinch({ ...event, scale });
+    event.target.handleEvent('pinch', { ...event, scale });
   }
 
   /**
@@ -121,7 +121,7 @@ class MessageHandler extends EventTarget(Object) {
    * @param {object} rotation
    */
   rotate(event, { rotation }) {
-    if (event.target.onrotate) event.target.onrotate({ ...event, rotation });
+    event.target.handleEvent('rotate', { ...event, rotation });
   }
 
   /**
@@ -131,14 +131,8 @@ class MessageHandler extends EventTarget(Object) {
    * @param {module:shared.Point2D} change
    */
   drag(event, { translation }) {
-    if (event.target.ondrag) {
-      const d = event.view.transformPointChange(translation.x, translation.y);
-      event.target.ondrag({
-        ...event,
-        dx: d.x,
-        dy: d.y,
-      });
-    }
+    const d = event.view.transformPointChange(translation.x, translation.y);
+    event.target.handleEvent('drag', { ...event, dx: d.x, dy: d.y });
   }
 
   /**
@@ -150,7 +144,7 @@ class MessageHandler extends EventTarget(Object) {
   swipe(event, data) {
     const { target } = event;
     const { velocity, direction } = data;
-    if (target.onswipe) target.onswipe({ ...event, velocity, direction });
+    event.target.handleEvent('swipe', { ...event, velocity, direction });
   }
 }
 

--- a/src/server/MessageHandler.js
+++ b/src/server/MessageHandler.js
@@ -173,19 +173,6 @@ class MessageHandler {
   }
 
   /**
-   * Send Message to clients to dispatch custom Client event.
-   *
-   * @param {string} event name of the user-defined event.
-   * @param {object} payload argument to pass to the event handler.
-   */
-  dispatch(action, payload) {
-    const dreport = new DataReporter({
-      data: { action, payload },
-    });
-    new Message(Message.DISPATCH, dreport).emitWith(this.workspace.namespace);
-  }
-
-  /**
    * Handle Server event.
    *
    * @param {string} event name of the event.

--- a/src/server/MessageHandler.js
+++ b/src/server/MessageHandler.js
@@ -28,16 +28,13 @@ class MessageHandler {
     this.workspace = workspace;
 
     /**
-     * Layout handler, for when clients connect to the application.
-     *
-     * @type {function}
-     */
-    this.onconnect = null;
-
-    /**
      * Custom event listeners. Maps string events names to arrays of functions.
      * Functions will be called with two arguments: the event object, and the
      * view object.
+     *
+     * Handlers can also be connected directly as "onX" properties of the
+     * object, however only one handler can be connected per event type in this
+     * manner.
      *
      * @type {object}
      */
@@ -187,13 +184,15 @@ class MessageHandler {
    * Handle custom Server event dispatched by a client.
    *
    * @param {string} event name of the event.
-   * @param {any} payload argument to pass to the event handler.
+   * @param {object} payload argument to pass to the event handler.
    */
-  handleCustomEvent(event, payload, view) {
-    if (!this.listeners[event] || this.listeners[event].length === 0) {
+  handleEvent(event, payload) {
+    const callback_name = `on${event}`;
+    if (!this[callback_name] && (!this.listeners[event] || this.listeners[event].length === 0)) {
       return console.warn(`Server is not listening for custom event "${event}"`);
     }
-    this.listeners[event].forEach((listener) => listener(payload, view));
+    if (this[callback_name]) this[callback_name](payload);
+    this.listeners[event].forEach((listener) => listener(payload));
   }
 
   /**

--- a/src/server/MessageHandler.js
+++ b/src/server/MessageHandler.js
@@ -31,8 +31,8 @@ class MessageHandler {
 
     /**
      * Custom event listeners. Maps string events names to arrays of functions.
-     * Functions will be called with two arguments: the event object, and the
-     * view object.
+     * Functions will be called with one argument: an event object. Contents
+     * will depend on the type of event.
      *
      * Handlers can also be connected directly as "onX" properties of the
      * object, however only one handler can be connected per event type in this
@@ -186,7 +186,7 @@ class MessageHandler {
   }
 
   /**
-   * Handle custom Server event dispatched by a client.
+   * Handle Server event.
    *
    * @param {string} event name of the event.
    * @param {object} payload argument to pass to the event handler.

--- a/src/server/MessageHandler.js
+++ b/src/server/MessageHandler.js
@@ -1,13 +1,8 @@
-/*
- * WAMS code to be executed in the client browser.
- *
- * Author: Michael van der Kamp
- */
-
 'use strict';
 
 const { Message, DataReporter } = require('../shared.js');
 const { actions } = require('../predefined');
+const { EventTarget } = require('../mixins.js');
 
 const EVENTS = Object.freeze(['connect', 'disconnect']);
 
@@ -20,30 +15,16 @@ const EVENTS = Object.freeze(['connect', 'disconnect']);
  * @param {module:server.WorkSpace} workspace - the model used when responding
  * to messages.
  */
-class MessageHandler {
-  constructor(workspace) {
+class MessageHandler extends EventTarget(Object) {
+  constructor(workspace, ...args) {
+    super(...args);
+
     /**
      * The model to access when responding to messages.
      *
      * @type {module:server.WorkSpace}
      */
     this.workspace = workspace;
-
-    /**
-     * Custom event listeners. Maps string events names to arrays of functions.
-     * Functions will be called with one argument: an event object. Contents
-     * will depend on the type of event.
-     *
-     * Handlers can also be connected directly as "onX" properties of the
-     * object, however only one handler can be connected per event type in this
-     * manner.
-     *
-     * @type {object}
-     */
-    this.listeners = {};
-    EVENTS.forEach((event_name) => {
-      this.listeners[event_name] = [];
-    });
   }
 
   /**
@@ -170,48 +151,6 @@ class MessageHandler {
     const { target } = event;
     const { velocity, direction } = data;
     if (target.onswipe) target.onswipe({ ...event, velocity, direction });
-  }
-
-  /**
-   * Handle Server event.
-   *
-   * @param {string} event name of the event.
-   * @param {object} payload argument to pass to the event handler.
-   */
-  handleEvent(event, payload) {
-    console.debug(`handleEvent: "${event}"`);
-    const callback_name = `on${event}`;
-    if (!this[callback_name] && (!this.listeners[event] || this.listeners[event].length === 0)) {
-      return console.warn(`Server is not listening for custom event "${event}"`);
-    }
-    if (this[callback_name]) this[callback_name](payload);
-    this.listeners[event].forEach((listener) => listener(payload));
-  }
-
-  /**
-   * Add a listener for the given event.
-   *
-   * @param {string} event name of the event.
-   * @param {function} listener function to call when the event is dispatched.
-   */
-  addEventListener(event, listener) {
-    if (!this.listeners[event]) this.listeners[event] = [];
-    this.listeners[event].push(listener);
-  }
-
-  /**
-   * Remove a listener for the given event.
-   *
-   * @param {string} event name of the event.
-   * @param {function} listener function to call when the event is dispatched.
-   * @returns {boolean} true if the listener was removed, false if it was not
-   */
-  removeEventListener(event, listener) {
-    if (!this.listeners[event]) return false;
-    const index = this.listeners[event].indexOf(listener);
-    if (index === -1) return false;
-    this.listeners[event].splice(index, 1);
-    return true;
   }
 }
 

--- a/src/server/MessageHandler.js
+++ b/src/server/MessageHandler.js
@@ -35,7 +35,9 @@ class MessageHandler {
     this.onconnect = null;
 
     /**
-     * Custom event listeners and handlers.
+     * Custom event listeners. Maps string events names to arrays of functions.
+     * Functions will be called with two arguments: the event object, and the
+     * view object.
      *
      * @type {object}
      */
@@ -188,10 +190,36 @@ class MessageHandler {
    * @param {any} payload argument to pass to the event handler.
    */
   handleCustomEvent(event, payload, view) {
-    if (!this.listeners[event]) {
+    if (!this.listeners[event] || this.listeners[event].length === 0) {
       return console.warn(`Server is not listening for custom event "${event}"`);
     }
-    this.listeners[event](payload, view);
+    this.listeners[event].forEach((listener) => listener(payload, view));
+  }
+
+  /**
+   * Add a listener for the given event.
+   *
+   * @param {string} event name of the event.
+   * @param {function} listener function to call when the event is dispatched.
+   */
+  addEventListener(event, listener) {
+    if (!this.listeners[event]) this.listeners[event] = [];
+    this.listeners[event].push(listener);
+  }
+
+  /**
+   * Remove a listener for the given event.
+   *
+   * @param {string} event name of the event.
+   * @param {function} listener function to call when the event is dispatched.
+   * @returns {boolean} true if the listener was removed, false if it was not
+   */
+  removeEventListener(event, listener) {
+    if (!this.listeners[event]) return false;
+    const index = this.listeners[event].indexOf(listener);
+    if (index === -1) return false;
+    this.listeners[event].splice(index, 1);
+    return true;
   }
 }
 

--- a/src/server/MessageHandler.js
+++ b/src/server/MessageHandler.js
@@ -187,6 +187,7 @@ class MessageHandler {
    * @param {object} payload argument to pass to the event handler.
    */
   handleEvent(event, payload) {
+    console.debug(`handleEvent: "${event}"`);
     const callback_name = `on${event}`;
     if (!this[callback_name] && (!this.listeners[event] || this.listeners[event].length === 0)) {
       return console.warn(`Server is not listening for custom event "${event}"`);

--- a/src/server/ServerController.js
+++ b/src/server/ServerController.js
@@ -174,7 +174,11 @@ class ServerController {
     this.view.releaseLockedItem();
     this.socket.disconnect(true);
     if (this.messageHandler.ondisconnect) {
-      this.messageHandler.ondisconnect(this.view, this.device, this.group);
+      this.messageHandler.ondisconnect({
+        view: this.view,
+        device: this.device,
+        group: this.group,
+      });
     }
     return true;
   }
@@ -190,7 +194,11 @@ class ServerController {
   layout({ width, height }) {
     this.setSize(width, height);
     if (this.messageHandler.onconnect) {
-      this.messageHandler.onconnect(this.view, this.device, this.group);
+      this.messageHandler.onconnect({
+        view: this.view,
+        device: this.device,
+        group: this.group,
+      });
     }
     new Message(Message.ADD_SHADOW, this.view).emitWith(this.socket.broadcast);
     new Message(Message.UD_VIEW, this.view).emitWith(this.socket);

--- a/src/server/ServerController.js
+++ b/src/server/ServerController.js
@@ -173,13 +173,11 @@ class ServerController {
     this.group.removeView(this.view);
     this.view.releaseLockedItem();
     this.socket.disconnect(true);
-    if (this.messageHandler.ondisconnect) {
-      this.messageHandler.ondisconnect({
-        view: this.view,
-        device: this.device,
-        group: this.group,
-      });
-    }
+    this.messageHandler.handleEvent('disconnect', {
+      view: this.view,
+      device: this.device,
+      group: this.group,
+    });
     return true;
   }
 
@@ -193,13 +191,11 @@ class ServerController {
    */
   layout({ width, height }) {
     this.setSize(width, height);
-    if (this.messageHandler.onconnect) {
-      this.messageHandler.onconnect({
-        view: this.view,
-        device: this.device,
-        group: this.group,
-      });
-    }
+    this.messageHandler.handleEvent('connect', {
+      view: this.view,
+      device: this.device,
+      group: this.group,
+    });
     new Message(Message.ADD_SHADOW, this.view).emitWith(this.socket.broadcast);
     new Message(Message.UD_VIEW, this.view).emitWith(this.socket);
   }

--- a/src/server/ServerController.js
+++ b/src/server/ServerController.js
@@ -15,7 +15,7 @@ const Device = require('./Device.js');
 
 // Symbols to mark these methods as intended for internal use only.
 const symbols = Object.freeze({
-  attachListeners: Symbol('attachListeners'),
+  attachSocketIoListeners: Symbol('attachSocketIoListeners'),
   fullStateReport: Symbol('fullStateReport'),
 });
 
@@ -94,7 +94,7 @@ class ServerController {
      * Automatically begin operations by registering Message listeners and
      * Informing the client on the current state of the model.
      */
-    this[symbols.attachListeners]();
+    this[symbols.attachSocketIoListeners]();
     this[symbols.fullStateReport]();
   }
 
@@ -102,10 +102,10 @@ class ServerController {
    * Attaches listeners to the socket. Only listens to message types existing on
    * the Message class object.
    *
-   * @alias [@@attachListeners]
+   * @alias [@@attachSocketIoListeners]
    * @memberof module:server.ServerController
    */
-  [symbols.attachListeners]() {
+  [symbols.attachSocketIoListeners]() {
     const listeners = {
       // For the server to inform about changes to the model
       [Message.ADD_ELEMENT]: NOP,

--- a/src/server/ServerController.js
+++ b/src/server/ServerController.js
@@ -141,7 +141,7 @@ class ServerController {
       [Message.BLUR]: () => this.group.clearInputsFromView(this.view.id),
 
       [Message.DISPATCH]: ({ data }) => {
-        this.messageHandler.handleCustomEvent(data.action, data.payload, this.view);
+        this.messageHandler.handleEvent(data.action, { ...data.payload, view: this.view });
       },
     };
 

--- a/src/server/ServerController.js
+++ b/src/server/ServerController.js
@@ -134,15 +134,11 @@ class ServerController {
       [Message.SWIPE]: this.messageHandler.handle('swipe', this.view),
       [Message.TRANSFORM]: this.messageHandler.handle('transform', this.view),
       [Message.RESIZE]: (data) => this.resize(data),
-      [Message.TRACK]: ({ data }) => {
-        this.messageHandler.track(data, this.view);
-      },
+      [Message.TRACK]: ({ data }) => this.messageHandler.track(data, this.view),
 
       // Multi-device gesture related
       [Message.POINTER]: (event) => this.pointerEvent(event),
-      [Message.BLUR]: () => {
-        this.group.clearInputsFromView(this.view.id);
-      },
+      [Message.BLUR]: () => this.group.clearInputsFromView(this.view.id),
 
       [Message.DISPATCH]: ({ data }) => {
         this.messageHandler.handleCustomEvent(data.action, data.payload, this.view);

--- a/src/server/ServerController.js
+++ b/src/server/ServerController.js
@@ -141,7 +141,7 @@ class ServerController {
       [Message.BLUR]: () => this.group.clearInputsFromView(this.view.id),
 
       [Message.DISPATCH]: ({ data }) => {
-        this.messageHandler.handleEvent(data.action, { ...data.payload, view: this.view });
+        this.messageHandler.send(data.action, { ...data.payload, view: this.view });
       },
     };
 
@@ -173,7 +173,7 @@ class ServerController {
     this.group.removeView(this.view);
     this.view.releaseLockedItem();
     this.socket.disconnect(true);
-    this.messageHandler.handleEvent('disconnect', {
+    this.messageHandler.send('disconnect', {
       view: this.view,
       device: this.device,
       group: this.group,
@@ -191,7 +191,7 @@ class ServerController {
    */
   layout({ width, height }) {
     this.setSize(width, height);
-    this.messageHandler.handleEvent('connect', {
+    this.messageHandler.send('connect', {
       view: this.view,
       device: this.device,
       group: this.group,

--- a/src/server/ServerElement.js
+++ b/src/server/ServerElement.js
@@ -44,7 +44,7 @@ class ServerElement extends Identifiable(Hittable(WamsElement)) {
   /*
    * Publish a general notification about the status of the image.
    */
-  emitPublication() {
+  _emitPublication() {
     new Message(Message.UD_ITEM, this).emitWith(this.namespace);
   }
 

--- a/src/server/ServerGroup.js
+++ b/src/server/ServerGroup.js
@@ -57,7 +57,7 @@ class ServerGroup extends Identifiable(Hittable(Item)) {
   /*
    * Publish a general notification about the status of the group.
    */
-  emitPublication() {
+  _emitPublication() {
     new Message(Message.UD_ITEM, this).emitWith(this.namespace);
   }
 

--- a/src/server/ServerImage.js
+++ b/src/server/ServerImage.js
@@ -44,7 +44,7 @@ class ServerImage extends Identifiable(Hittable(WamsImage)) {
   /*
    * Publish a general notification about the status of the image.
    */
-  emitPublication() {
+  _emitPublication() {
     new Message(Message.UD_ITEM, this).emitWith(this.namespace);
   }
 

--- a/src/server/ServerItem.js
+++ b/src/server/ServerItem.js
@@ -56,7 +56,7 @@ class ServerItem extends Identifiable(Hittable(Item)) {
   /*
    * Publish a general notification about the status of the item.
    */
-  emitPublication() {
+  _emitPublication() {
     new Message(Message.UD_ITEM, this).emitWith(this.namespace);
   }
 

--- a/src/server/ServerView.js
+++ b/src/server/ServerView.js
@@ -97,7 +97,7 @@ class ServerView extends Locker(Interactable(View)) {
    *
    * @override
    */
-  emitPublication() {
+  _emitPublication() {
     new Message(Message.UD_SHADOW, this).emitWith(this.socket.broadcast);
     new Message(Message.UD_VIEW, this).emitWith(this.socket);
   }

--- a/src/server/ServerView.js
+++ b/src/server/ServerView.js
@@ -109,6 +109,7 @@ class ServerView extends Locker(Interactable(View)) {
    * @param {object} payload argument to pass to the event handler.
    */
   dispatch(action, payload) {
+    console.debug(`dispatch: ${action} to View ${this.id}`);
     const dreport = new DataReporter({
       data: { action, payload },
     });

--- a/src/server/ServerView.js
+++ b/src/server/ServerView.js
@@ -103,7 +103,7 @@ class ServerView extends Locker(Interactable(View)) {
   }
 
   /**
-   * Send Message to clients to dispatch custom Client event.
+   * Send Message to this view to dispatch a user-defined event.
    *
    * @param {string} event name of the user-defined event.
    * @param {object} payload argument to pass to the event handler.

--- a/src/server/ServerViewGroup.js
+++ b/src/server/ServerViewGroup.js
@@ -128,7 +128,7 @@ class ServerViewGroup extends Locker(Lockable(Transformable2D(View))) {
    * @param {Namespace} socket - Socket.io socket for publishing changes.
    */
   spawnView(socket, index) {
-    const view = new ServerView(socket, { index, ...this });
+    const view = new ServerView(socket, { ...this, index });
     this.views.push(view);
     return view;
   }

--- a/src/server/ServerViewGroup.js
+++ b/src/server/ServerViewGroup.js
@@ -54,7 +54,8 @@ class ServerViewGroup extends Locker(Lockable(Transformable2D(View))) {
    * @param {number} id - Id of the view whose inputs should be cleared.
    */
   clearInputsFromView(id) {
-    this.gestureController.clearOutView(id);
+    // FIXME TODO: reinstate support for server-side gestures
+    // this.gestureController.clearOutView(id);
   }
 
   /*

--- a/src/server/TrackingSwitchboard.js
+++ b/src/server/TrackingSwitchboard.js
@@ -93,7 +93,7 @@ class TrackingSwitchboard {
    * connection.
    */
   accept(socket) {
-    socket.on('disconnect', () => this.disconnect());
+    socket.on('disconnect', this.disconnect.bind(this));
     logConnection(true);
   }
 

--- a/src/server/WorkSpace.js
+++ b/src/server/WorkSpace.js
@@ -121,17 +121,17 @@ class WorkSpace {
     const highestItem = this.items[0];
     // don't raise if item is already on top
     if (highestItem.id === item.id) return;
-    this.bringItemToTop(item);
+    this.bringItemToTop(item.id);
     item.publish();
   }
 
   /**
    * Bring item to top, so that it's above others.
    *
-   * @param {Item} item
+   * @param {number} id
    */
-  bringItemToTop(item) {
-    const index = this.items.indexOf(item);
+  bringItemToTop(id) {
+    const index = this.items.findIndex((el) => el.id === id);
     if (index < 0) throw new Error("Couldn't find item by id");
     this.items.unshift(...this.items.splice(index, 1));
   }

--- a/src/server/WorkSpace.js
+++ b/src/server/WorkSpace.js
@@ -121,17 +121,17 @@ class WorkSpace {
     const highestItem = this.items[0];
     // don't raise if item is already on top
     if (highestItem.id === item.id) return;
-    this.bringItemToTop(item.id);
+    this.bringItemToTop(item);
     item.publish();
   }
 
   /**
    * Bring item to top, so that it's above others.
    *
-   * @param {number} id
+   * @param {Item} item
    */
-  bringItemToTop(id) {
-    const index = this.items.findIndex((el) => el.id === id);
+  bringItemToTop(item) {
+    const index = this.items.indexOf(item);
     if (index < 0) throw new Error("Couldn't find item by id");
     this.items.unshift(...this.items.splice(index, 1));
   }

--- a/src/server/WorkSpace.js
+++ b/src/server/WorkSpace.js
@@ -121,8 +121,8 @@ class WorkSpace {
     const highestItem = this.items[0];
     // don't raise if item is already on top
     if (highestItem.id === item.id) return;
-    item.emitPublication();
     this.bringItemToTop(item.id);
+    item.publish();
   }
 
   /**

--- a/src/shared/Reporters.js
+++ b/src/shared/Reporters.js
@@ -386,11 +386,11 @@ const View = ReporterFactory({
    *
    * @name index
    * @type {number}
-   * @default null
+   * @default undefined
    * @memberof module:shared.View
    * @instance
    */
-  index: null,
+  index: undefined,
 });
 
 /**


### PR DESCRIPTION
This enables general event handling via a generic EventTarget mixin. Custom user events are handled through the same mixin as internal events. See `EventTarget` for details.

Can use `addEventListener(name, handler)` and `removeEventListener(name, handler)` for adding/removing listeners, or can attach `on{name}` callbacks as properties, e.g. `onconnect = handleConnect`. Send events to a target using `dispatchEvent(name, payload)`.

A next step to this would be to have these classes extend node's [EventEmitter](https://nodejs.org/api/events.html#class-eventemitter) class instead, which would greatly enhance their event capabilities! I think in order to do this we first need to refactor away the confusing and limiting Reporter framework (and replace it with some kind of Serializer approach).

Closes #18 