### PR TITLE
Revise walkthrough in readme and touch up examples

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: 🔨 Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: ".nvmrc"
+          node-version: "*"
 
       - name: 📦 Install Dependencies
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ To try out the examples, go to `examples/` and run as follows:
 
 ```bash
 node examples/[EXAMPLE_FILENAME]
+```
 
 ## For example:
 
+```bash
 node examples/polygons.js
 ```
 

--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ function smileFace(args) {
   return { ...args, sequence };
 }
 
-app.spawn(smileFace(900, 300));
+app.spawn(smileFace({ x: 900, y: 300 }));
 ```
 
 You can add interactivity to a custom item the same way as with predefined items. However, you first need to add a _hitbox_ to the item. This can be a bit confusing, since the hitbox will always be given (x, y) values as if its item is located a (0, 0). Put another way, the hitbox doesn't need to know anything about how the item is positioned or oriented in the WAMS workspace:

--- a/README.md
+++ b/README.md
@@ -443,11 +443,11 @@ const { table } = WAMS.predefined.layouts;
 const overlap = 200; // 200px overlap between screens
 const setTableLayout = table(overlap);
 
-function handleLayout({ view, device }) {  // note the {} brackets to destructure the event object
+function handleConnect({ view, device }) {  // note the {} brackets to destructure the event object
   setTableLayout(view, device);
 }
 
-app.on('connect', setTableLayout);
+app.on('connect', handleConnect);
 ```
 
 To see this layout in action, check out the `card-table.js` example.
@@ -465,11 +465,11 @@ const { line } = WAMS.predefined.layouts;
 const overlap = 200; // 200px overlap between screens
 const setLineLayout = line(overlap);
 
-function handleLayout(view, device) {
+function handleConnect(view, device) {
   setLineLayout(view, device);
 }
 
-app.onconnect = handleLayout;
+app.onconnect = handleConnect;
 ```
 
 To see this layout in action with multi-screen gestures, check out the `shared-polygons.js` example.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ const { square } = WAMS.predefined.items;
 app.spawn(square(200, 200, 100, "green"));
 ```
 
-This code creates a green square on the canvas with coordinates `{ x: 200, y: 200 }` and a side of `100`.
+This code creates a green square on the canvas with coordinates `{ x: 200, y: 200 }` and a length of `100`.
 
 ### Hello world: Multi-Screen
 
@@ -310,32 +310,25 @@ app.spawn(
 To make an item **draggable**, it's enough to attach the predefined drag action to the drag event:
 
 ```javascript
-...
 const item = app.spawn(items.square(200, 200, 100, 'green'));
 item.on('drag', actions.drag);
-...
 ```
 
 This looks much better. Now let's remove the square when you **click** on it. _To remove an item, use WAMS' `removeItem` method._
 
 ```js
-...
 item.on('click', () => app.removeItem(item));
-...
 ```
 
 Another cool interactive feature is **rotation**. To rotate an item, first add a `rotate` listener, (the predefined action will do the trick), and then grab the item with your mouse and hold **Control** key.
 
 ```js
-...
 item.on('rotate', actions.rotate);
-...
 ```
 
 You can also listen to **swipe** events on items (hold the item, quickly move it and release). To do that, add a `swipe` handler.
 
 ```js
-...
 function handleSwipe(event) {
   console.log(`Swipe registered!`);
   console.log(`Velocity: ${event.velocity}`);
@@ -343,16 +336,13 @@ function handleSwipe(event) {
   console.log(`X, Y: ${event.x}, ${event.y}`);
 }
 item.on('swipe', handleSwipe);
-...
 ```
 
 To move an item, you can use `moveBy` and `moveTo` item methods:
 
 ```js
-...
 // do this on a different item than the one that uses removeItem
 item.on('click', () => item.moveBy(100, -50));
-...
 ```
 
 Both methods accept `x` and `y` numbers that represent a vector (for `moveBy`) or the final position (for `moveTo`).

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ npm install
 
 ## Getting started
 
-The easiest way to get started is to follow the [Walkthrough](#walkthrough) tutorial below. More advanced users might want to check the [code documentation](https://hcilab.github.io/wams/) and the [examples](#examples). For a taste on how WAMS works, check the [live demo section](#live-demo).
+The easiest way to get started is to follow the [Walkthrough](#walkthrough) tutorial below. More advanced users might want to check the [code documentation](https://hcilab.github.io/wams/) and the [examples](#examples). ~For a taste on how WAMS works, check the [live demo section](#live-demo).~ (The live demo is currently broken).
 
 ## Examples
 
@@ -62,6 +62,8 @@ node examples/polygons.js
 ```
 
 ## Live Demo
+
+* (Currently broken)
 
 The [live demo](https://wams-player-demo.herokuapp.com/) is an example of a video-player with a distributed user interface. First, the player controls are displayed on the screen with the video. Go to the url with a second device or browser, and as a second view is connected, the controls are automatically moved to that view.
 

--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ function smileFace(args) {
   return { ...args, sequence };
 }
 
-app.spawn(smileFace({ x: 900, y: 300 }));
+app.spawn(smileFace({ x: 400, y: 300 }));
 ```
 
 You can add interactivity to a custom item the same way as with predefined items. However, you first need to add a _hitbox_ to the item. This can be a bit confusing, since the hitbox will always be given (x, y) values as if its item is located a (0, 0). Put another way, the hitbox doesn't need to know anything about how the item is positioned or oriented in the WAMS workspace:
@@ -519,7 +519,7 @@ function interactableSmileFace(args) {
 }
 
 // The Circle doesn't need to know that we're creating the smiley at (900, 300) in the workspace
-const item = app.spawn(interactableSmileFace({ x: 900, y: 300 }));
+const item = app.spawn(interactableSmileFace({ x: 400, y: 200 }));
 item.on('drag', actions.drag);
 ```
 

--- a/examples/card-table.js
+++ b/examples/card-table.js
@@ -198,7 +198,7 @@ function handleConnect({ view, device }) {
 }
 
 app.onconnect = handleConnect;
-app.listen(9700);
+app.listen(9000);
 
 /**
  * Draws a rounded rectangle using the current state of the canvas.

--- a/examples/card-table.js
+++ b/examples/card-table.js
@@ -175,7 +175,7 @@ function dealCards() {
         face: card,
         isFaceUp: false,
       })
-    )
+    );
     cardItem.on('click', flipCard);
     cardItem.on('drag', WAMS.predefined.actions.drag);
     cardItem.on('rotate', WAMS.predefined.actions.rotate);

--- a/examples/checkers.js
+++ b/examples/checkers.js
@@ -101,4 +101,4 @@ function handleConnect({ view }) {
 }
 
 app.addEventListener('connect', handleConnect);
-app.listen(9012);
+app.listen(9000);

--- a/examples/checkers.js
+++ b/examples/checkers.js
@@ -51,7 +51,7 @@ function spawnToken(x, y, userIdx, properties = {}) {
   let imgUrl = userIdx === 0 ? 'Green_border.png' : 'Blue_border.png';
 
   const radius = SQUARE_LENGTH / 2;
-  app.spawn({
+  const token = app.spawn({
     x,
     y,
     width: SQUARE_LENGTH,
@@ -60,9 +60,9 @@ function spawnToken(x, y, userIdx, properties = {}) {
     type: 'item/image',
     src: imgUrl,
     ownerIdx: userIdx,
-    ondrag: (e) => handleTokenDrag(e, userIdx),
     ...properties,
   });
+  token.on('drag', (e) => handleTokenDrag(e, userIdx));
 }
 
 for (let i = 0; i < 10; i += 1) {
@@ -95,10 +95,10 @@ function handleConnect({ view }) {
 
   centerViewNormal(view);
 
-  view.ondrag = WAMS.predefined.actions.drag;
-  view.onpinch = WAMS.predefined.actions.pinch;
-  view.onrotate = WAMS.predefined.actions.rotate;
+  view.on('drag', WAMS.predefined.actions.drag);
+  view.on('pinch', WAMS.predefined.actions.pinch);
+  view.on('rotate', WAMS.predefined.actions.rotate);
 }
 
-app.addEventListener('connect', handleConnect);
+app.on('connect', handleConnect);
 app.listen(9000);

--- a/examples/chess.js
+++ b/examples/chess.js
@@ -103,7 +103,7 @@ function spawnToken(x, y, userIdx, tokenIdx, properties = {}) {
     }
   }
 
-  app.spawn(
+  const token = app.spawn(
     WAMS.predefined.items.html(
       `<div><img src="${imgUrl}" width="${SQUARE_LENGTH}" height="${SQUARE_LENGTH}" /></div>`,
       SQUARE_LENGTH,
@@ -115,12 +115,12 @@ function spawnToken(x, y, userIdx, tokenIdx, properties = {}) {
         height: SQUARE_LENGTH,
         type,
         ownerIdx: userIdx,
-        ondrag: (e) => handleTokenDrag(e, userIdx),
         // rotation: event => handleRotate(event),
         ...properties,
       }
     )
   );
+  token.on('drag', (e) => handleTokenDrag(e, userIdx));
 }
 
 // Spawning all pieces iteratively
@@ -168,10 +168,10 @@ function handleConnect({ view }) {
 
   centerViewNormal(view);
 
-  view.ondrag = WAMS.predefined.actions.drag;
-  view.onpinch = WAMS.predefined.actions.pinch;
-  view.onrotate = WAMS.predefined.actions.rotate;
+  view.on('drag', WAMS.predefined.actions.drag);
+  view.on('pinch', WAMS.predefined.actions.pinch);
+  view.on('rotate', WAMS.predefined.actions.rotate);
 }
 
-app.onconnect = handleConnect;
+app.on('connect', handleConnect);
 app.listen(9000);

--- a/examples/chess.js
+++ b/examples/chess.js
@@ -174,4 +174,4 @@ function handleConnect({ view }) {
 }
 
 app.onconnect = handleConnect;
-app.listen(4000);
+app.listen(9000);

--- a/examples/confetti-custom-event.js
+++ b/examples/confetti-custom-event.js
@@ -38,7 +38,7 @@ function square(x, y, view, color) {
 }
 
 function spawnSquare(event, color) {
-  const item = app.spawn(square(event.x, event.y, event.view, color))
+  const item = app.spawn(square(event.x, event.y, event.view, color));
   item.on('drag', WAMS.predefined.actions.drag);
 }
 

--- a/examples/confetti-custom-event.js
+++ b/examples/confetti-custom-event.js
@@ -70,4 +70,4 @@ app.on('mouseup', (event) => {
   spawnSquare(event);
 });
 app.onconnect = handleConnect;
-app.listen(9013);
+app.listen(9000);

--- a/examples/confetti-custom-event.js
+++ b/examples/confetti-custom-event.js
@@ -34,20 +34,19 @@ function square(x, y, view, color) {
     type: 'colour',
     scale: 1 / view.scale,
     rotation: view.rotation,
-    ondrag: WAMS.predefined.actions.drag,
   };
 }
 
 function spawnSquare(event, color) {
-  if (!color) app.spawn(square(event.x, event.y, event.view));
-  else app.spawn(square(event.x, event.y, event.view, color));
+  const item = app.spawn(square(event.x, event.y, event.view, color))
+  item.on('drag', WAMS.predefined.actions.drag);
 }
 
 function handleConnect({ view }) {
-  view.onpinch = WAMS.predefined.actions.pinch;
-  view.ondrag = WAMS.predefined.actions.drag;
-  view.onrotate = WAMS.predefined.actions.rotate;
-  // view.onclick = spawnSquare;
+  view.on('pinch', WAMS.predefined.actions.pinch);
+  view.on('drag', WAMS.predefined.actions.drag);
+  view.on('rotate', WAMS.predefined.actions.rotate);
+  // view.on('click', spawnSquare);
 }
 
 app.on('mousedown', (event) => {
@@ -69,5 +68,5 @@ app.on('mouseup', (event) => {
   }
   spawnSquare(event);
 });
-app.onconnect = handleConnect;
+app.on('connect', handleConnect);
 app.listen(9000);

--- a/examples/confetti.js
+++ b/examples/confetti.js
@@ -39,4 +39,4 @@ function handleConnect({ view }) {
 }
 
 app.onconnect = handleConnect;
-app.listen(9013);
+app.listen(9000);

--- a/examples/confetti.js
+++ b/examples/confetti.js
@@ -32,11 +32,11 @@ function spawnSquare(event) {
 }
 
 function handleConnect({ view }) {
-  view.onpinch = WAMS.predefined.actions.pinch;
-  view.ondrag = WAMS.predefined.actions.drag;
-  view.onrotate = WAMS.predefined.actions.rotate;
-  view.onclick = spawnSquare;
+  view.on('pinch', WAMS.predefined.actions.pinch);
+  view.on('drag', WAMS.predefined.actions.drag);
+  view.on('rotate', WAMS.predefined.actions.rotate);
+  view.on('click', spawnSquare);
 }
 
-app.onconnect = handleConnect;
+app.on('connect', handleConnect);
 app.listen(9000);

--- a/examples/dollar_sign_and_paper.js
+++ b/examples/dollar_sign_and_paper.js
@@ -18,9 +18,9 @@ const app = new WAMS.Application({
 });
 
 function handleConnect({ view }) {
-  view.onpinch = WAMS.predefined.actions.pinch;
-  view.ondrag = WAMS.predefined.actions.drag;
-  view.onrotate = WAMS.predefined.actions.rotate;
+  view.on('pinch', WAMS.predefined.actions.pinch);
+  view.on('drag', WAMS.predefined.actions.drag);
+  view.on('rotate', WAMS.predefined.actions.rotate);
 }
-app.onconnect = handleConnect;
+app.on('connect', handleConnect);
 app.listen(9000);

--- a/examples/dollar_sign_and_paper.js
+++ b/examples/dollar_sign_and_paper.js
@@ -23,4 +23,4 @@ function handleConnect({ view }) {
   view.onrotate = WAMS.predefined.actions.rotate;
 }
 app.onconnect = handleConnect;
-app.listen(9013);
+app.listen(9000);

--- a/examples/drawing-app.js
+++ b/examples/drawing-app.js
@@ -58,7 +58,7 @@ class DrawingApp {
     this.app.on('set-control', this.updateControlType.bind(this));
     this.app.on('set-color', this.setColor.bind(this));
     this.app.on('set-width', this.setWidth.bind(this));
-    this.app.onconnect = this.handleConnect.bind(this);
+    this.app.on('connect', this.handleConnect.bind(this));
     this.app.listen(9000);
   }
 
@@ -85,12 +85,13 @@ class DrawingApp {
 
   updateControlType({ type, view }) {
     this.controlType = type;
-    view.ondrag = type === 'pan' ? actions.drag : this.draw.bind(this);
+    view.removeAllListeners('drag');
+    view.on('drag', type === 'pan' ? actions.drag : this.draw.bind(this));
   }
 
   handleConnect({ view }) {
-    view.ondrag = WAMS.predefined.actions.drag;
-    view.onpinch = WAMS.predefined.actions.zoom;
+    view.on('drag', WAMS.predefined.actions.drag);
+    view.on('pinch', WAMS.predefined.actions.zoom);
   }
 }
 

--- a/examples/drawing-app.js
+++ b/examples/drawing-app.js
@@ -59,7 +59,7 @@ class DrawingApp {
     this.app.on('set-color', this.setColor.bind(this));
     this.app.on('set-width', this.setWidth.bind(this));
     this.app.onconnect = this.handleConnect.bind(this);
-    this.app.listen(3000);
+    this.app.listen(9000);
   }
 
   draw(event) {

--- a/examples/drawing-app.js
+++ b/examples/drawing-app.js
@@ -69,7 +69,6 @@ class DrawingApp {
     // const fromY = event.y - event.dy;
     const toX = event.x;
     const toY = event.y;
-    console.log('draw', color, width, toX, toY);
     const line = new CanvasSequence();
     // line.beginPath()
     // line.moveTo(fromX, fromY);

--- a/examples/elements.js
+++ b/examples/elements.js
@@ -40,4 +40,4 @@ function handleConnect({ view }) {
 }
 
 app.onconnect = handleConnect;
-app.listen(9002);
+app.listen(9000);

--- a/examples/elements.js
+++ b/examples/elements.js
@@ -17,10 +17,6 @@ function element(x, y, view) {
     type: 'button',
     scale: 1 / view.scale,
     rotation: view.rotation,
-    onpinch: WAMS.predefined.actions.pinch,
-    ondrag: WAMS.predefined.actions.drag,
-    onrotate: WAMS.predefined.actions.rotate,
-    onclick: removeElement,
   });
 }
 
@@ -29,15 +25,19 @@ function removeElement(event) {
 }
 
 function spawnElement(event) {
-  app.spawn(element(event.x, event.y, event.view));
+  const item = app.spawn(element(event.x, event.y, event.view));
+  item.on('pinch', WAMS.predefined.actions.pinch);
+  item.on('drag', WAMS.predefined.actions.drag);
+  item.on('rotate', WAMS.predefined.actions.rotate);
+  item.on('click', removeElement);
 }
 
 function handleConnect({ view }) {
-  view.onpinch = WAMS.predefined.actions.pinch;
-  view.ondrag = WAMS.predefined.actions.drag;
-  view.onrotate = WAMS.predefined.actions.rotate;
-  view.onclick = spawnElement;
+  view.on('pinch', WAMS.predefined.actions.pinch);
+  view.on('drag', WAMS.predefined.actions.drag);
+  view.on('rotate', WAMS.predefined.actions.rotate);
+  view.on('click', spawnElement);
 }
 
-app.onconnect = handleConnect;
+app.on('connect', handleConnect);
 app.listen(9000);

--- a/examples/jumbotron.js
+++ b/examples/jumbotron.js
@@ -17,7 +17,7 @@ const app = new WAMS.Application({
 
 const scale = 2;
 
-app.spawn(
+const lisa = app.spawn(
   image('monaLisa.jpg', {
     width: 1200,
     height: 1815,
@@ -25,11 +25,11 @@ app.spawn(
     y: 0,
     type: 'mona',
     scale,
-    ondrag: WAMS.predefined.actions.drag,
-    onpinch: WAMS.predefined.actions.pinch,
-    onrotate: WAMS.predefined.actions.rotate,
   })
 );
+lisa.on('drag', WAMS.predefined.actions.drag);
+lisa.on('pinch', WAMS.predefined.actions.pinch);
+lisa.on('rotate', WAMS.predefined.actions.rotate);
 
 const jumbotronLayout = jumbotron(1200 * scale);
 
@@ -37,7 +37,7 @@ function handleConnect({ view }) {
   jumbotronLayout(view);
 }
 
-app.onconnect = handleConnect;
+app.on('connect', handleConnect);
 app.listen(9000);
 
 /**

--- a/examples/jumbotron.js
+++ b/examples/jumbotron.js
@@ -38,7 +38,7 @@ function handleConnect({ view }) {
 }
 
 app.onconnect = handleConnect;
-app.listen(9010);
+app.listen(9000);
 
 /**
  * Generates a handler that places devices in a jumbotron.

--- a/examples/pairedWorkers.js
+++ b/examples/pairedWorkers.js
@@ -40,4 +40,4 @@ app.spawn(
   })
 );
 
-app.listen(9003);
+app.listen(9000);

--- a/examples/pairedWorkers.js
+++ b/examples/pairedWorkers.js
@@ -14,30 +14,30 @@ const app = new WAMS.Application({
   staticDir: path.join(__dirname, './img'),
 });
 
-app.spawn(
+const scream = app.spawn(
   image('scream.png', {
     x: 400,
     y: 400,
     width: 800,
     height: 1013,
     scale: 0.25,
-    ondrag: WAMS.predefined.actions.drag,
-    onrotate: WAMS.predefined.actions.rotate,
-    onpinch: WAMS.predefined.actions.pinch,
   })
 );
+scream.on('drag', WAMS.predefined.actions.drag);
+scream.on('rotate', WAMS.predefined.actions.rotate);
+scream.on('pinch', WAMS.predefined.actions.pinch);
 
-app.spawn(
+const lisa = app.spawn(
   image('monaLisa.jpg', {
     x: 200,
     y: 200,
     width: 1200,
     height: 1815,
     scale: 0.2,
-    ondrag: WAMS.predefined.actions.drag,
-    onrotate: WAMS.predefined.actions.rotate,
-    onpinch: WAMS.predefined.actions.pinch,
   })
 );
+lisa.on('drag', WAMS.predefined.actions.drag);
+lisa.on('rotate', WAMS.predefined.actions.rotate);
+lisa.on('pinch', WAMS.predefined.actions.pinch);
 
 app.listen(9000);

--- a/examples/photo-lens.js
+++ b/examples/photo-lens.js
@@ -34,4 +34,4 @@ function handleConnect({ view }) {
 }
 
 app.onconnect = handleConnect;
-app.listen(9011);
+app.listen(9000);

--- a/examples/photo-lens.js
+++ b/examples/photo-lens.js
@@ -25,13 +25,13 @@ app.spawn(
 );
 
 function handleConnect({ view }) {
-  view.onrotate = WAMS.predefined.actions.rotate;
+  view.on('rotate', WAMS.predefined.actions.rotate);
   if (view.index > 0) {
     view.scale = 2.5;
-    view.ondrag = WAMS.predefined.actions.drag;
-    view.onpinch = WAMS.predefined.actions.pinch;
+    view.on('drag', WAMS.predefined.actions.drag);
+    view.on('pinch', WAMS.predefined.actions.pinch);
   }
 }
 
-app.onconnect = handleConnect;
+app.on('connect', handleConnect);
 app.listen(9000);

--- a/examples/pick-n-drop.js
+++ b/examples/pick-n-drop.js
@@ -40,7 +40,7 @@ function handleConnect({ view, device, group }) {
   dimensions[view.index] = { x: device.x, y: device.y, width: device.width, height: device.height };
 }
 
-app.onconnect = handleConnect;
+app.on('connect', handleConnect);
 app.listen(9000);
 
 function moveScreenToScreen(currentView, targetView) {
@@ -69,10 +69,8 @@ function viewContainsItem(view, item) {
 }
 
 function spawnImage(x, y) {
-  return app.spawn(
+  const item = app.spawn(
     image('dribble.png', {
-      ondrag: WAMS.predefined.actions.drag,
-      onrotate: WAMS.predefined.actions.rotate,
       width: 1600,
       height: 1200,
       scale: 1 / 4,
@@ -80,4 +78,7 @@ function spawnImage(x, y) {
       y,
     })
   );
+  item.on('drag', WAMS.predefined.actions.drag);
+  item.on('rotate', WAMS.predefined.actions.rotate);
+  return item;
 }

--- a/examples/pick-n-drop.js
+++ b/examples/pick-n-drop.js
@@ -41,7 +41,7 @@ function handleConnect({ view, device, group }) {
 }
 
 app.onconnect = handleConnect;
-app.listen(9700);
+app.listen(9000);
 
 function moveScreenToScreen(currentView, targetView) {
   const centeredBelowPosX = targetView.x + targetView.width / 2 - currentView.width / 2;

--- a/examples/polygons.js
+++ b/examples/polygons.js
@@ -17,10 +17,6 @@ function polygon(x, y, view) {
       y,
       type: 'colour',
       scale: 1 / view.scale,
-      onclick: removeItem,
-      onpinch: WAMS.predefined.actions.pinch,
-      onrotate: WAMS.predefined.actions.rotate,
-      ondrag: WAMS.predefined.actions.drag,
     }
   );
 }
@@ -30,15 +26,19 @@ function removeItem(event) {
 }
 
 function spawnItem(event) {
-  app.spawn(polygon(event.x, event.y, event.view));
+  const item = app.spawn(polygon(event.x, event.y, event.view));
+  item.on('click', removeItem);
+  item.on('pinch', WAMS.predefined.actions.pinch);
+  item.on('rotate', WAMS.predefined.actions.rotate);
+  item.on('drag', WAMS.predefined.actions.drag);
 }
 
 function handleConnect({ view }) {
-  view.onclick = spawnItem;
-  view.onpinch = WAMS.predefined.actions.pinch;
-  view.onrotate = WAMS.predefined.actions.rotate;
-  view.ondrag = WAMS.predefined.actions.drag;
+  view.on('click', spawnItem);
+  view.on('pinch', WAMS.predefined.actions.pinch);
+  view.on('rotate', WAMS.predefined.actions.rotate);
+  view.on('drag', WAMS.predefined.actions.drag);
 }
 
-app.onconnect = handleConnect;
+app.on('connect', handleConnect);
 app.listen(9000);

--- a/examples/polygons.js
+++ b/examples/polygons.js
@@ -41,4 +41,4 @@ function handleConnect({ view }) {
 }
 
 app.onconnect = handleConnect;
-app.listen(9014);
+app.listen(9000);

--- a/examples/projected.js
+++ b/examples/projected.js
@@ -36,14 +36,14 @@ function viewSetup({ view, device, group }) {
   if (view.index === 0) {
     view.scaleBy(0.6);
   } else if (view.index === 1) {
-    group.ondrag = WAMS.predefined.actions.drag;
+    group.on('drag', WAMS.predefined.actions.drag);
     view.scaleBy(3.4);
     view.moveTo(1615, 2800);
   } else {
     view.scaleBy(1.7);
-    view.ondrag = WAMS.predefined.actions.drag;
+    view.on('drag', WAMS.predefined.actions.drag);
   }
 }
 
-app.onconnect = viewSetup;
+app.on('connect', viewSetup);
 app.listen(9000);

--- a/examples/projected.js
+++ b/examples/projected.js
@@ -46,4 +46,4 @@ function viewSetup({ view, device, group }) {
 }
 
 app.onconnect = viewSetup;
-app.listen(3500);
+app.listen(9000);

--- a/examples/scaffold.js
+++ b/examples/scaffold.js
@@ -3,6 +3,6 @@
 const WAMS = require('..');
 const app = new WAMS.Application();
 
-app.onconnect = ({ view }) => {};
+app.on('connect', ({ view }) => {});
 
 app.listen(9000);

--- a/examples/scaffold.js
+++ b/examples/scaffold.js
@@ -5,4 +5,4 @@ const app = new WAMS.Application();
 
 app.onconnect = ({ view }) => {};
 
-app.listen(8080);
+app.listen(9000);

--- a/examples/shared-polygons.js
+++ b/examples/shared-polygons.js
@@ -46,4 +46,4 @@ function handleConnect({ view, device, group }) {
 }
 
 app.onconnect = handleConnect;
-app.listen(9500);
+app.listen(9000);

--- a/examples/shared-polygons.js
+++ b/examples/shared-polygons.js
@@ -19,10 +19,6 @@ function polygon(x, y, view) {
       y,
       type: 'colour',
       scale: 1 / view.scale,
-      onclick: removeItem,
-      onpinch: WAMS.predefined.actions.pinch,
-      onrotate: WAMS.predefined.actions.rotate,
-      ondrag: WAMS.predefined.actions.drag,
     }
   );
 }
@@ -32,18 +28,22 @@ function removeItem(event) {
 }
 
 function spawnItem(event) {
-  app.spawn(polygon(event.x, event.y, event.view));
+  const item = app.spawn(polygon(event.x, event.y, event.view));
+  item.on('click', removeItem);
+  item.on('pinch', WAMS.predefined.actions.pinch);
+  item.on('rotate', WAMS.predefined.actions.rotate);
+  item.on('drag', WAMS.predefined.actions.drag);
 }
 
 // use predefined "line layout"
 const linelayout = WAMS.predefined.layouts.line(200);
 function handleConnect({ view, device, group }) {
-  group.onclick = spawnItem;
-  group.onpinch = WAMS.predefined.actions.pinch;
-  group.onrotate = WAMS.predefined.actions.rotate;
-  group.ondrag = WAMS.predefined.actions.drag;
+  group.on('click', spawnItem);
+  group.on('pinch', WAMS.predefined.actions.pinch);
+  group.on('rotate', WAMS.predefined.actions.rotate);
+  group.on('drag', WAMS.predefined.actions.drag);
   linelayout(view, device);
 }
 
-app.onconnect = handleConnect;
+app.on('connect', handleConnect);
 app.listen(9000);

--- a/examples/swipe-drawing.js
+++ b/examples/swipe-drawing.js
@@ -43,4 +43,4 @@ function handleConnect({ view }) {
 }
 
 app.onconnect = handleConnect;
-app.listen(9002);
+app.listen(9000);

--- a/examples/swipe-drawing.js
+++ b/examples/swipe-drawing.js
@@ -14,8 +14,8 @@ const app = new WAMS.Application();
  */
 function handleSwipe({ x, y, velocity, direction }) {
   const cidx = Math.ceil(velocity * 10) % WAMS.colours.length;
-  console.count('swipes');
-  console.dir({ msg: 'Swipe registered', x, y, velocity, direction });
+  // console.count('swipes');
+  // console.dir({ msg: 'Swipe registered', x, y, velocity, direction });
   app.spawn(
     WAMS.predefined.items.rectangle(x, y, velocity * 25, 32, WAMS.colours[cidx], {
       rotation: -direction,
@@ -33,7 +33,7 @@ function handleDrag({ x, y, dx, dy }) {
       rotation: Math.atan2(dx, dy),
     })
   );
-  console.log('Line: { x: %s, y: %s, length: %s, rotation: %s }', line.x, line.y, length, line.rotation);
+  // console.log('Line: { x: %s, y: %s, length: %s, rotation: %s }', line.x, line.y, length, line.rotation);
   setTimeout(() => app.removeItem(line), 3000);
 }
 

--- a/examples/swipe-drawing.js
+++ b/examples/swipe-drawing.js
@@ -38,9 +38,9 @@ function handleDrag({ x, y, dx, dy }) {
 }
 
 function handleConnect({ view }) {
-  view.onswipe = handleSwipe;
-  view.ondrag = handleDrag;
+  view.on('swipe', handleSwipe);
+  view.on('drag', handleDrag);
 }
 
-app.onconnect = handleConnect;
+app.on('connect', handleConnect);
 app.listen(9000);

--- a/examples/video-player.js
+++ b/examples/video-player.js
@@ -52,7 +52,7 @@ class VideoPlayer {
     this.app.on('video-time-sync', this.handleVideoTimeSync.bind(this));
     this.app.onconnect = this.handleConnect.bind(this);
     this.app.ondisconnect = this.handleDisconnect.bind(this);
-    this.app.listen(3000);
+    this.app.listen(9000);
   }
 
   handlePlayerStateChange({ playing }) {

--- a/examples/video-player.js
+++ b/examples/video-player.js
@@ -50,8 +50,8 @@ class VideoPlayer {
     this.app.on('forward', this.handleForward.bind(this));
     this.app.on('replay', this.handleReplay.bind(this));
     this.app.on('video-time-sync', this.handleVideoTimeSync.bind(this));
-    this.app.onconnect = this.handleConnect.bind(this);
-    this.app.ondisconnect = this.handleDisconnect.bind(this);
+    this.app.on('connect', this.handleConnect.bind(this));
+    this.app.on('disconnect', this.handleDisconnect.bind(this));
     this.app.listen(9000);
   }
 
@@ -110,10 +110,10 @@ class VideoPlayer {
         height,
         playing,
         type: 'controls',
-        ondrag: WAMS.predefined.actions.drag,
-        onpinch: WAMS.predefined.actions.pinch,
       })
     );
+    this.controls.on('drag', WAMS.predefined.actions.drag);
+    this.controls.on('pinch', WAMS.predefined.actions.pinch);
 
     console.log(this.controls);
   }

--- a/examples/video.js
+++ b/examples/video.js
@@ -30,39 +30,54 @@ const iframe = (src) =>
     allowfullscreen
   ></iframe>`;
 
-app.spawn(
+const moonTouchdownVideo = app.spawn(
   WAMS.predefined.items.html(topbarred(iframe('https://www.youtube.com/embed/RONIax0_1ec')), 560, 50, {
     x: X,
     y: 50,
     width: WIDTH,
     height: HEIGHT,
     type: 'video',
-    onpinch: WAMS.predefined.actions.pinch,
-    onrotate: WAMS.predefined.actions.rotate,
-    ondrag: WAMS.predefined.actions.drag,
+    lockZ: true,
   })
 );
+moonTouchdownVideo.on('pinch', WAMS.predefined.actions.pinch);
+moonTouchdownVideo.on('rotate', WAMS.predefined.actions.rotate);
+moonTouchdownVideo.on('drag', WAMS.predefined.actions.drag);
 
-app.spawn(
+const falconHeavyVideo = app.spawn(
   WAMS.predefined.items.html(topbarred(iframe('https://www.youtube.com/embed/l5I8jaMsHYk')), 560, 50, {
     x: X,
     y: 465,
     width: WIDTH,
     height: HEIGHT,
     type: 'video',
-    onpinch: WAMS.predefined.actions.pinch,
-    onrotate: WAMS.predefined.actions.rotate,
-    ondrag: WAMS.predefined.actions.drag,
+    lockZ: true,
   })
 );
+moonTouchdownVideo.on('pinch', WAMS.predefined.actions.pinch);
+moonTouchdownVideo.on('rotate', WAMS.predefined.actions.rotate);
+moonTouchdownVideo.on('drag', WAMS.predefined.actions.drag);
+
+const falconHeavyVideo = app.spawn(
+  WAMS.predefined.items.html(topbarred(iframe('https://www.youtube.com/embed/l5I8jaMsHYk')), 560, 50, {
+    x: X,
+    y: 465,
+    width: WIDTH,
+    height: HEIGHT,
+    type: 'video',
+  })
+);
+falconHeavyVideo.on('pinch', WAMS.predefined.actions.pinch);
+falconHeavyVideo.on('rotate', WAMS.predefined.actions.rotate);
+falconHeavyVideo.on('drag', WAMS.predefined.actions.drag);
 
 function handleConnect({ view }) {
   // allowing the whole view to
   // be moved around, rotated and scaled
-  view.onpinch = WAMS.predefined.actions.pinch;
-  view.onrotate = WAMS.predefined.actions.rotate;
-  view.ondrag = WAMS.predefined.actions.drag;
+  view.on('pinch', WAMS.predefined.actions.pinch);
+  view.on('rotate', WAMS.predefined.actions.rotate);
+  view.on('drag', WAMS.predefined.actions.drag);
 }
 
-app.onconnect = handleConnect;
+app.on('connect', handleConnect);
 app.listen(9000);

--- a/examples/video.js
+++ b/examples/video.js
@@ -54,19 +54,6 @@ const falconHeavyVideo = app.spawn(
     lockZ: true,
   })
 );
-moonTouchdownVideo.on('pinch', WAMS.predefined.actions.pinch);
-moonTouchdownVideo.on('rotate', WAMS.predefined.actions.rotate);
-moonTouchdownVideo.on('drag', WAMS.predefined.actions.drag);
-
-const falconHeavyVideo = app.spawn(
-  WAMS.predefined.items.html(topbarred(iframe('https://www.youtube.com/embed/l5I8jaMsHYk')), 560, 50, {
-    x: X,
-    y: 465,
-    width: WIDTH,
-    height: HEIGHT,
-    type: 'video',
-  })
-);
 falconHeavyVideo.on('pinch', WAMS.predefined.actions.pinch);
 falconHeavyVideo.on('rotate', WAMS.predefined.actions.rotate);
 falconHeavyVideo.on('drag', WAMS.predefined.actions.drag);

--- a/examples/video.js
+++ b/examples/video.js
@@ -15,7 +15,7 @@ const topbarred = (html) =>
     <div 
       width="560" 
       height="50"
-      style="background-color:green; height:50px;"
+      style="background-color:green; height:50px; border: solid black;"
     ></div>
     ${html}
   </div>`;

--- a/examples/video.js
+++ b/examples/video.js
@@ -65,4 +65,4 @@ function handleConnect({ view }) {
 }
 
 app.onconnect = handleConnect;
-app.listen(9020);
+app.listen(9000);

--- a/examples/walkthrough-paper.js
+++ b/examples/walkthrough-paper.js
@@ -5,20 +5,18 @@ const { square } = WAMS.predefined.items;
 const { line } = WAMS.predefined.layouts;
 
 function spawnSquare(event) {
-  app.spawn(
-    square(event.x - 50, event.y - 50, 100, 'green', {
-      ondrag: WAMS.predefined.actions.drag,
-      onrotate: WAMS.predefined.actions.rotate,
-      onpinch: WAMS.predefined.actions.pinch,
-    })
-  );
+  const item = app.spawn(square(event.x - 50, event.y - 50, 100, 'green'));
+  item.on('drag', WAMS.predefined.actions.drag);
+  item.on('rotate', WAMS.predefined.actions.rotate);
+  item.on('pinch', WAMS.predefined.actions.pinch);
+  return item;
 }
 
 const linelayout = line();
 function handleConnect({ view, device }) {
-  view.onclick = spawnSquare;
+  view.on('click', spawnSquare);
   linelayout(view, device);
 }
 
-app.onconnect = handleConnect;
+app.on('connect', handleConnect);
 app.listen(9000);

--- a/examples/walkthrough-paper.js
+++ b/examples/walkthrough-paper.js
@@ -21,4 +21,4 @@ function handleConnect({ view, device }) {
 }
 
 app.onconnect = handleConnect;
-app.listen(3600);
+app.listen(9000);

--- a/examples/webpage-sharing.js
+++ b/examples/webpage-sharing.js
@@ -36,16 +36,16 @@ function bottomBarred(html) {
 }
 
 function spawnIframe(event, url) {
-  app.spawn(
+  const iframe = app.spawn(
     html(bottomBarred(`<iframe width="560" height="315" src="${url}" frameborder="0"></iframe>`), 560, 365, {
       x: event.x,
       y: event.y,
       width: 560,
       height: 365,
-      ondrag: handleIframeDrag,
-      onclick: (e) => app.removeItem(e.target),
     })
   );
+  iframe.on('drag', handleIframeDrag);
+  iframe.on('click', (e) => app.removeItem(e.target));
 }
 
 function setLayout(view) {
@@ -61,10 +61,10 @@ function handleConnect({ view }) {
 
   setLayout(view);
 
-  view.onclick = (ev) => spawnIframe(ev, 'http://www.example.com');
+  view.on('click', (ev) => spawnIframe(ev, 'http://www.example.com'));
 }
 
-app.onconnect = handleConnect;
+app.on('connect', handleConnect);
 app.listen(9000);
 
 function handleIframeDrag(event) {

--- a/examples/webpage-sharing.js
+++ b/examples/webpage-sharing.js
@@ -65,7 +65,7 @@ function handleConnect({ view }) {
 }
 
 app.onconnect = handleConnect;
-app.listen(9021);
+app.listen(9000);
 
 function handleIframeDrag(event) {
   if (event.view.index !== 0 && event.target.y <= 0) {

--- a/examples/webpages.js
+++ b/examples/webpages.js
@@ -12,7 +12,7 @@ const { html } = WAMS.predefined.items;
 // function that returns input html wrapped with a top bar
 function topbarred(html) {
   return `${
-    '<div>' + '<div width="560" height="50" ' + 'style="background-color:green; height:50px;"></div>'
+    '<div>' + '<div width="560" height="50" ' + 'style="background-color:green; height:50px; border: solid black;"></div>'
   }${html}</div>`;
 }
 

--- a/examples/webpages.js
+++ b/examples/webpages.js
@@ -54,4 +54,4 @@ function handleConnect({ view }) {
 }
 
 app.onconnect = handleConnect;
-app.listen(9021);
+app.listen(9000);

--- a/examples/webpages.js
+++ b/examples/webpages.js
@@ -21,7 +21,7 @@ function topbarred(html) {
     </div>`;
 }
 
-app.spawn(
+const gamefaqs = app.spawn(
   html(
     topbarred('<iframe width="560" height="315" src="https://www.gamefaqs.com" frameborder="0"></iframe>'),
     560,
@@ -32,31 +32,33 @@ app.spawn(
       width: 560,
       height: 365,
       type: 'video',
-      onpinch: WAMS.predefined.actions.pinch,
-      onrotate: WAMS.predefined.actions.rotate,
-      ondrag: WAMS.predefined.actions.drag,
+      lockZ: true,
     }
   )
 );
+gamefaqs.on('pinch', WAMS.predefined.actions.pinch);
+gamefaqs.on('rotate', WAMS.predefined.actions.rotate);
+gamefaqs.on('drag', WAMS.predefined.actions.drag);
 
-app.spawn(
+const xkcd = app.spawn(
   html(topbarred('<iframe width="560" height="315" src="https://www.xkcd.com" frameborder="0"></iframe>'), 560, 50, {
     x: 400,
     y: 465,
     width: 560,
     height: 365,
     type: 'video',
-    onpinch: WAMS.predefined.actions.pinch,
-    onrotate: WAMS.predefined.actions.rotate,
-    ondrag: WAMS.predefined.actions.drag,
+    lockZ: true,
   })
 );
+xkcd.on('pinch', WAMS.predefined.actions.pinch);
+xkcd.on('rotate', WAMS.predefined.actions.rotate);
+xkcd.on('drag', WAMS.predefined.actions.drag);
 
 function handleConnect({ view }) {
-  view.onpinch = WAMS.predefined.actions.pinch;
-  view.onrotate = WAMS.predefined.actions.rotate;
-  view.ondrag = WAMS.predefined.actions.drag;
+  view.on('pinch', WAMS.predefined.actions.pinch);
+  view.on('rotate', WAMS.predefined.actions.rotate);
+  view.on('drag', WAMS.predefined.actions.drag);
 }
 
-app.onconnect = handleConnect;
+app.on('connect', handleConnect);
 app.listen(9000);

--- a/examples/webpages.js
+++ b/examples/webpages.js
@@ -11,9 +11,14 @@ const { html } = WAMS.predefined.items;
 
 // function that returns input html wrapped with a top bar
 function topbarred(html) {
-  return `${
-    '<div>' + '<div width="560" height="50" ' + 'style="background-color:green; height:50px; border: solid black;"></div>'
-  }${html}</div>`;
+  return `<div>
+      <div
+        width="560"
+        height="50"
+        style="background-color:green; height:50px; border: solid black;"
+      ></div>
+      ${html}
+    </div>`;
 }
 
 app.spawn(

--- a/src/mixins/EventTarget.js
+++ b/src/mixins/EventTarget.js
@@ -63,10 +63,10 @@ const EventTarget = (superclass) => {
     eventNames() {
       return Object.keys(this.listeners);
     }
-  };
+  }
   EventTarget.prototype.on = EventTarget.prototype.addEventListener;
   EventTarget.prototype.off = EventTarget.prototype.removeEventListener;
   return EventTarget;
-}
+};
 
 module.exports = EventTarget;

--- a/src/mixins/EventTarget.js
+++ b/src/mixins/EventTarget.js
@@ -58,6 +58,19 @@ const EventTarget = (superclass) => {
     }
 
     /**
+     * Remove all listeners, or those of the specified `eventName`
+     *
+     * @param {string} eventName optional
+     */
+    removeAllListeners(eventName) {
+      if (eventName === undefined) {
+        this.listeners = {};
+      } else {
+        delete this.listeners[eventName];
+      }
+    }
+
+    /**
      * @returns {string[]} an array listing the events for which the target has registered listeners.
      */
     eventNames() {

--- a/src/mixins/EventTarget.js
+++ b/src/mixins/EventTarget.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const EventTarget = (superclass) =>
+const EventTarget = (superclass) => {
   class EventTarget extends superclass {
     constructor(...args) {
       super(...args);
@@ -56,6 +56,17 @@ const EventTarget = (superclass) =>
       this.listeners[event].splice(index, 1);
       return true;
     }
+
+    /**
+     * @returns {string[]} an array listing the events for which the target has registered listeners.
+     */
+    eventNames() {
+      return Object.keys(this.listeners);
+    }
   };
+  EventTarget.prototype.on = EventTarget.prototype.addEventListener;
+  EventTarget.prototype.off = EventTarget.prototype.removeEventListener;
+  return EventTarget;
+}
 
 module.exports = EventTarget;

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -214,16 +214,6 @@ class Application extends EventTarget(Object) {
     });
     new Message(Message.DISPATCH, dreport).emitWith(this.workspace.namespace);
   }
-
-  /**
-   * Set up a custom Server event listener.
-   *
-   * @param {*} event name of the custom Server event.
-   * @param {*} handler handler of the custom event.
-   */
-  on(event, handler) {
-    this.addEventListener(event, handler);
-  }
 }
 
 module.exports = Application;

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -6,7 +6,7 @@ const os = require('os');
 const IO = require('socket.io');
 
 // Local classes, etc
-const { constants } = require('../shared.js');
+const { constants, DataReporter, Message } = require('../shared.js');
 const Router = require('./Router.js');
 const Switchboard = require('./Switchboard.js');
 const WorkSpace = require('./WorkSpace.js');

--- a/src/server/ServerGroup.js
+++ b/src/server/ServerGroup.js
@@ -35,17 +35,15 @@ class ServerGroup extends Identifiable(Hittable(Item)) {
     this.setMeasures();
 
     this.setParentForItems();
-
-    this.setupInteractions();
   }
 
-  setupInteractions() {
-    if (this.ondrag) {
-      this.items.forEach((item) => {
-        // trying to drag any of the items will drag the whole group
-        item.ondrag = this.ondrag;
+  on(eventName, listener) {
+    this.items.forEach((item) => {
+      item.on(eventName, (event) => {
+        event.target = this;
+        return listener(event);
       });
-    }
+    });
   }
 
   /*

--- a/src/server/ServerView.js
+++ b/src/server/ServerView.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { DataReporter, IdStamper, Message, View } = require('../shared.js');
-const { Interactable, Locker } = require('../mixins.js');
+const { Interactable, Locker, EventTarget } = require('../mixins.js');
 
 const STAMPER = new IdStamper();
 
@@ -18,7 +18,7 @@ const STAMPER = new IdStamper();
  * @param {Object} [ values ] - Object with user supplied values describing the
  * view.
  */
-class ServerView extends Locker(Interactable(View)) {
+class ServerView extends Locker(Interactable(EventTarget(View))) {
   constructor(socket, values = {}) {
     super(values);
 

--- a/src/server/WorkSpace.js
+++ b/src/server/WorkSpace.js
@@ -105,14 +105,14 @@ class WorkSpace {
   _canLock(item) {
     const eventNames = item.eventNames();
     return (
-      item.ondrag
-      || item.onpinch
-      || item.onrotate
-      || item.onswipe
-      || eventNames.includes('drag')
-      || eventNames.includes('pinch')
-      || eventNames.includes('rotate')
-      || eventNames.includes('swipe')
+      item.ondrag ||
+      item.onpinch ||
+      item.onrotate ||
+      item.onswipe ||
+      eventNames.includes('drag') ||
+      eventNames.includes('pinch') ||
+      eventNames.includes('rotate') ||
+      eventNames.includes('swipe')
     );
   }
 

--- a/src/server/WorkSpace.js
+++ b/src/server/WorkSpace.js
@@ -107,10 +107,12 @@ class WorkSpace {
     return (
       item.ondrag
       || item.onpinch
-      || item.onrotate 
+      || item.onrotate
+      || item.onswipe
       || eventNames.includes('drag')
       || eventNames.includes('pinch')
       || eventNames.includes('rotate')
+      || eventNames.includes('swipe')
     );
   }
 

--- a/src/server/WorkSpace.js
+++ b/src/server/WorkSpace.js
@@ -92,7 +92,7 @@ class WorkSpace {
     const itemClass = item.constructor.name;
     if (itemClass !== 'ServerView' && itemClass !== 'ServerViewGroup') {
       if (!item.lockZ) this.raiseItem(item);
-      if (item.ondrag || item.onpinch || item.onrotate) {
+      if (this._canLock(item)) {
         view.obtainLockOnItem(item);
       } else {
         view.obtainLockOnItem(view);
@@ -100,6 +100,18 @@ class WorkSpace {
     } else {
       view.obtainLockOnItem(view);
     }
+  }
+
+  _canLock(item) {
+    const eventNames = item.eventNames();
+    return (
+      item.ondrag
+      || item.onpinch
+      || item.onrotate 
+      || eventNames.includes('drag')
+      || eventNames.includes('pinch')
+      || eventNames.includes('rotate')
+    );
   }
 
   /**


### PR DESCRIPTION
- Set the port for all examples to 9000, so that when switching from one example to another you can just refresh the page.
- Add missing EventTarget support for ServerViews
- Add on/off aliasing directly to EventTarget
- Fix missing imports
- Make better use of EventTarget, e.g. when automagically deciding whether to allow locks on an item, and for item groups.
- Use e.g. `item.on('drag', handler)` instead of `item.ondrag = handler` in examples.
- Suggest using `npm install <git repo>` in walkthrough instead of `git clone <git repo>`.