### PR TITLE
Convert layout functions to classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ function spawnSquare() {
   greenSquare.on('drag', actions.drag);
 }
 
-const linelayout = layouts.line(300); // 300px overlap betweens views
+const line = new layouts.Line(300); // 300px overlap betweens views
 
 function handleConnect({ view, device }) {
   view.on('click', spawnSquare);
-  linelayout(view, device);
+  line.layout(view, device);
 }
 
 app.on('connect', handleConnect);
@@ -460,13 +460,13 @@ Places users in a line, with the given amount of overlap. Best used with either 
 // application config should include
 // "useMultiScreenGestures: true"
 
-const { line } = WAMS.predefined.layouts;
+const { Line } = WAMS.predefined.layouts;
 
 const overlap = 200; // 200px overlap between screens
-const setLineLayout = line(overlap);
+const line = new Line(overlap);
 
 function handleConnect({ view, device }) {  // note the {} brackets to destructure the event object
-  setLineLayout(view, device);
+  line.layout(view, device);
 }
 
 app.on('connect', handleConnect);

--- a/examples/card-table.js
+++ b/examples/card-table.js
@@ -34,6 +34,7 @@ const app = new WAMS.Application({
   color: 'green',
   backgroundImage: 'green-table.jpeg',
   shadows: true,
+  status: true,
   clientLimit: 5,
   staticDir: path.join(__dirname, '/img'),
 });
@@ -197,12 +198,8 @@ function flipCard(event) {
   card.isFaceUp = !card.isFaceUp;
 }
 
-const tableLayout = WAMS.predefined.layouts.table(20);
-function handleConnect({ view, device }) {
-  tableLayout(view, device);
-}
-
-app.on('connect', handleConnect);
+const table = new WAMS.predefined.layouts.Table(20);
+app.on('connect', ({ view, device }) => table.layout(view, device));
 app.listen(9000);
 
 /**

--- a/examples/pick-n-drop.js
+++ b/examples/pick-n-drop.js
@@ -1,7 +1,7 @@
 const WAMS = require('..');
 const path = require('path');
 const { image } = WAMS.predefined.items;
-const { line } = WAMS.predefined.layouts;
+const { Line } = WAMS.predefined.layouts;
 
 const dimensions = [];
 const deepSpace = { x: 99999, y: 99999 };
@@ -29,13 +29,13 @@ app.on('deviceFarFromScreens', (data) => {
   if (currentView) moveScreenWithItems(currentView, deepSpace.x, deepSpace.y);
 });
 
-const setLayout = line(0);
+const line = new Line(0);
 function handleConnect({ view, device, group }) {
   if (view.index >= 2) {
     // send to deep space :)
     view.moveTo(deepSpace.x, deepSpace.y);
   } else {
-    setLayout(view, device);
+    line.layout(view, device);
   }
   dimensions[view.index] = { x: device.x, y: device.y, width: device.width, height: device.height };
 }

--- a/examples/shared-polygons.js
+++ b/examples/shared-polygons.js
@@ -43,9 +43,9 @@ viewGroup.on('pinch', WAMS.predefined.actions.pinch);
 viewGroup.on('rotate', WAMS.predefined.actions.rotate);
 viewGroup.on('drag', WAMS.predefined.actions.drag);
 
-const linelayout = WAMS.predefined.layouts.line(200);
+const line = new WAMS.predefined.layouts.Line(200);
 function handleConnect({ view, device }) {
-  linelayout(view, device);
+  line.layout(view, device);
 }
 
 app.on('connect', handleConnect);

--- a/examples/walkthrough-paper.js
+++ b/examples/walkthrough-paper.js
@@ -6,7 +6,7 @@ const app = new WAMS.Application({
 });
 
 const { square } = WAMS.predefined.items;
-const { line } = WAMS.predefined.layouts;
+const { Line } = WAMS.predefined.layouts;
 
 function spawnSquare(event) {
   const item = app.spawn(square(event.x - 50, event.y - 50, 100, 'green'));
@@ -18,9 +18,9 @@ function spawnSquare(event) {
 
 app.switchboard.group.on('click', spawnSquare);
 
-const linelayout = line(200);
+const line = new Line(200);
 function handleConnect({ view, device }) {
-  linelayout(view, device);
+  line.layout(view, device);
 }
 
 app.on('connect', handleConnect);

--- a/src/predefined/layouts.js
+++ b/src/predefined/layouts.js
@@ -28,7 +28,7 @@ class Table {
 
   constructor(overlap) {
     if (overlap == undefined) {
-      // or if overalap is null, since using == instead of ===
+      // or if overlap is null, since using == instead of ===
       throw new Error('overlap must be defined for Table layout');
     }
     this.overlap = overlap;
@@ -120,7 +120,7 @@ class Table {
 class Line {
   constructor(overlap) {
     if (overlap == undefined) {
-      // or if overalap is null, since using == instead of ===
+      // or if overlap is null, since using == instead of ===
       throw new Error('overlap must be defined for Line layout');
     }
     this.overlap = overlap;
@@ -150,7 +150,31 @@ class Line {
   }
 }
 
+/**
+ * @deprecated
+ * @param {number} overlap
+ * @returns {Table}
+ * @memberof module:predefined.layouts
+ */
+function table(overlap) {
+  console.warn('WARNING: `table(overlap)` is deprecated, use `new Table(overlap)` instead.');
+  return new Table(overlap);
+}
+
+/**
+ * @deprecated
+ * @param {number} overlap
+ * @returns {Line}
+ * @memberof module:predefined.layouts
+ */
+function line(overlap) {
+  console.warn('WARNING: `line(overlap)` is deprecated, use `new Line(overlap)` instead.');
+  return new Line(overlap);
+}
+
 module.exports = {
   Line,
   Table,
+  line,
+  table,
 };

--- a/src/predefined/layouts.js
+++ b/src/predefined/layouts.js
@@ -10,88 +10,101 @@ const { constants } = require('../shared.js');
  */
 
 /**
- * Generates a handler that places users around a table, with the given amount
- * of overlap. The first user will be the "table", and their position when they
- * join is stamped as the outline of the table. The next four users are
- * positioned, facing inwards, around the four sides of the table.
+ * Places users around a table, with the given amount of overlap. The first user
+ * will be the "table", and their position when they join is stamped as the
+ * outline of the table. The next four users are positioned, facing inwards,
+ * around the four sides of the table.
  *
  * @memberof module:predefined.layouts
  *
  * @param {number} overlap
- *
- * @returns {module:server.ListenerTypes.LayoutListener} A WAMS layout handler
- * function that places users around a table.
  */
-function table(overlap) {
-  let table = null;
-  let bottomLeft = null;
-  let bottomRight = null;
-  let topLeft = null;
-  let topRight = null;
+class Table {
+  TABLE = 0;
+  BOTTOM = 1;
+  LEFT = 2;
+  TOP = 3;
+  RIGHT = 4;
 
-  const TABLE = 0;
-  const BOTTOM = 1;
-  const LEFT = 2;
-  const TOP = 3;
-  const RIGHT = 4;
-
-  function layoutTable(view, device) {
-    table = view;
-    bottomLeft = view.bottomLeft;
-    bottomRight = view.bottomRight;
-    topLeft = view.topLeft;
-    topRight = view.topRight;
+  constructor(overlap) {
+    if (overlap == undefined) {
+      // or if overalap is null, since using == instead of ===
+      throw new Error('overlap must be defined for Table layout');
+    }
+    this.overlap = overlap;
+    this.table = null;
+    this.bottomLeft = null;
+    this.bottomRight = null;
+    this.topLeft = null;
+    this.topRight = null;
   }
 
-  function layoutBottom(view, device) {
-    view.moveTo(bottomLeft.x, bottomLeft.y - overlap);
-    device.moveTo(bottomLeft.x, bottomLeft.y - overlap);
+  layoutTable(view, device) {
+    this.table = view;
+    this.bottomLeft = view.bottomLeft;
+    this.bottomRight = view.bottomRight;
+    this.topLeft = view.topLeft;
+    this.topRight = view.topRight;
   }
 
-  function layoutLeft(view, device) {
-    view.moveTo(topLeft.x + overlap, topLeft.y);
+  layoutBottom(view, device) {
+    view.moveTo(this.bottomLeft.x, this.bottomLeft.y - this.overlap);
+    device.moveTo(this.bottomLeft.x, this.bottomLeft.y - this.overlap);
+  }
+
+  layoutLeft(view, device) {
+    view.moveTo(this.topLeft.x + this.overlap, this.topLeft.y);
     view.rotateBy(constants.ROTATE_90);
-    device.moveTo(topLeft.x + overlap, topLeft.y);
+    device.moveTo(this.topLeft.x + this.overlap, this.topLeft.y);
     device.rotateBy(constants.ROTATE_90);
   }
 
-  function layoutTop(view, device) {
-    view.moveTo(topRight.x, topRight.y + overlap);
+  layoutTop(view, device) {
+    view.moveTo(this.topRight.x, this.topRight.y + this.overlap);
     view.rotateBy(constants.ROTATE_180);
-    device.moveTo(topRight.x, topRight.y + overlap);
+    device.moveTo(this.topRight.x, this.topRight.y + this.overlap);
     device.rotateBy(constants.ROTATE_180);
   }
 
-  function layoutRight(view, device) {
-    view.moveTo(bottomRight.x - overlap, bottomRight.y);
+  layoutRight(view, device) {
+    view.moveTo(this.bottomRight.x - this.overlap, this.bottomRight.y);
     view.rotateBy(-constants.ROTATE_90);
-    device.moveTo(bottomRight.x - overlap, bottomRight.y);
+    device.moveTo(this.bottomRight.x - this.overlap, this.bottomRight.y);
     device.rotateBy(-constants.ROTATE_90);
   }
 
-  function dependOnTable(fn) {
-    return function layoutDepender(view, device) {
-      if (table == null) {
-        setTimeout(() => layoutDepender(view, device), 0);
-      } else {
-        fn(view, device);
-      }
-    };
-  }
-
-  const userFns = [];
-  userFns[TABLE] = layoutTable;
-  userFns[BOTTOM] = dependOnTable(layoutBottom);
-  userFns[LEFT] = dependOnTable(layoutLeft);
-  userFns[TOP] = dependOnTable(layoutTop);
-  userFns[RIGHT] = dependOnTable(layoutRight);
-
-  function handleLayout(view, device) {
+  layout(view, device) {
     const index = view.index > 0 ? (view.index % 4) + 1 : 0;
-    userFns[index](view, device);
+    console.log('INDEX', index);
+    if (index == this.TABLE) {
+      console.log('TABLE', view.index);
+      this.layoutTable(view, device);
+      return;
+    }
+    if (this.table == null) {
+      // console.log('TABLE NOT SET', view.index);
+      setTimeout(this.layout.bind(this, view, device), 0);
+      return;
+    }
+    switch (index) {
+      case this.BOTTOM:
+        console.log('BOTTOM', view.index);
+        this.layoutBottom(view, device);
+        break;
+      case this.LEFT:
+        console.log('LEFT', view.index);
+        this.layoutLeft(view, device);
+        break;
+      case this.TOP:
+        console.log('TOP', view.index);
+        this.layoutTop(view, device);
+        break;
+      case this.RIGHT:
+        console.log('RIGHT', view.index);
+        this.layoutRight(view, device);
+        break;
+    }
   }
-
-  return handleLayout;
 }
 
 /**
@@ -141,5 +154,5 @@ function line(overlap) {
 
 module.exports = {
   line,
-  table,
+  Table,
 };

--- a/src/predefined/layouts.js
+++ b/src/predefined/layouts.js
@@ -108,51 +108,49 @@ class Table {
 }
 
 /**
- * Generates a handler that places users in a line, with the given amount of
- * overlap. Best used with either server-side gestures or when users are unable
- * to manipulate their views.
+ * Places users in a line, with the given amount of overlap. Best used with
+ * either server-side gestures or when users are unable to manipulate their
+ * views.
  * - Valid for use with server-side gestures.
  *
  * @memberof module:predefined.layouts
  *
  * @param {number} overlap
- *
- * @returns {module:server.ListenerTypes.LayoutListener} A WAMS layout handler
- * function that places users in a line.
  */
-function line(overlap) {
-  if (overlap == undefined) {
-    // or if overalap is null, since using == instead of ===
-    throw new Error('overlap must be defined for line layout');
+class Line {
+  constructor(overlap) {
+    if (overlap == undefined) {
+      // or if overalap is null, since using == instead of ===
+      throw new Error('overlap must be defined for Line layout');
+    }
+    this.overlap = overlap;
+    this.views = [];
+    this.deviceRights = [];
   }
-  const views = [];
-  const rights = [];
 
-  function layout(view, device) {
+  layout(view, device) {
     if (view.index > 0) {
-      if (views[view.index - 1] == null) {
-        setTimeout(() => layout(view, device), 0);
+      if (this.views[view.index - 1] == null) {
+        setTimeout(this.layout.bind(this, view, device), 0);
       } else {
-        const prev = views[view.index - 1];
-        const change = prev.transformPointChange(overlap, 0);
+        const prev = this.views[view.index - 1];
+        const change = prev.transformPointChange(this.overlap, 0);
         const anchor = prev.topRight.minus(change);
         view.moveTo(anchor.x, anchor.y);
 
-        const side = rights[view.index - 1] - overlap;
+        const side = this.deviceRights[view.index - 1] - this.overlap;
         device.moveTo(side, 0);
-        rights[view.index] = side + device.width;
-        views[view.index] = view;
+        this.deviceRights[view.index] = side + device.width;
+        this.views[view.index] = view;
       }
     } else {
-      rights[0] = device.width;
-      views[0] = view;
+      this.deviceRights[0] = device.width;
+      this.views[0] = view;
     }
   }
-
-  return layout;
 }
 
 module.exports = {
-  line,
+  Line,
   Table,
 };


### PR DESCRIPTION
Convert table() and line() to classes, but continue to provide functions with deprecation warnings.
