### PR TITLE
Distinguish between the global viewspace and a view group

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ function flipCard(event) {
 
 ### Grouped items
 
-Sometimes you would like to spawn several items and then move or drag them together. To do that easily, you can use the `createGroup` method (see in the [code documentation](https://hcilab.github.io/wams/module-server.Application.html#createGroup)):
+Sometimes you would like to spawn several items and then move or drag them together. To do that easily, you can use the `createItemGroup` method (see in the [code documentation](https://hcilab.github.io/wams/module-server.Application.html#createItemGroup)):
 
 ```javascript
 const items = [];
@@ -634,7 +634,7 @@ items.push(app.spawn(square(100, 100, 200, "yellow")));
 
 items.push(app.spawn(square(150, 150, 200, "blue")));
 
-const group = app.createGroup({ items });
+const group = app.createItemGroup({ items });
 group.on('drag', actions.drag);
 
 group.moveTo(500, 300);

--- a/examples/drawing-app.js
+++ b/examples/drawing-app.js
@@ -94,7 +94,6 @@ class DrawingApp {
       view.off('pinch', actions.pinch);
       view.on('drag', this.boundDraw);
     }
-    // view.on('pointermove', type === 'pan' ? actions.drag : this.draw.bind(this));
   }
 
   handleConnect({ view }) {

--- a/examples/pick-n-drop.js
+++ b/examples/pick-n-drop.js
@@ -17,20 +17,20 @@ spawnImage(200, 300);
 app.on('deviceNearScreen', (data) => {
   const { deviceIndex, nearIndex } = data;
   console.log(`[Tracker] View ${deviceIndex} is close to ${nearIndex}`);
-  const currentView = app.group.views[deviceIndex];
-  const nearView = app.group.views[nearIndex];
+  const currentView = app.viewspace.views[deviceIndex];
+  const nearView = app.viewspace.views[nearIndex];
   if (currentView) moveScreenToScreen(currentView, nearView);
 });
 
 app.on('deviceFarFromScreens', (data) => {
   const { deviceIndex } = data;
   console.log(`[Tracker] View ${deviceIndex} is far from screens`);
-  const currentView = app.group.views[deviceIndex];
+  const currentView = app.viewspace.views[deviceIndex];
   if (currentView) moveScreenWithItems(currentView, deepSpace.x, deepSpace.y);
 });
 
 const line = new Line(0);
-function handleConnect({ view, device, group }) {
+function handleConnect({ view, device }) {
   if (view.index >= 2) {
     // send to deep space :)
     view.moveTo(deepSpace.x, deepSpace.y);

--- a/examples/projected.js
+++ b/examples/projected.js
@@ -21,7 +21,7 @@ app.on('position', (data) => {
   // x and y are floats from 0 to 1, representing relative
   // position of the tracker in space on each dimension
   const { x, y } = data.position;
-  const trackedView = app.group.views[data.deviceIndex];
+  const trackedView = app.viewspace.views[data.deviceIndex];
   if (trackedView) {
     trackedView.moveTo(x * TOTAL_WIDTH, y * TOTAL_HEIGHT);
   }
@@ -36,7 +36,7 @@ app.spawn(
   })
 );
 
-function viewSetup({ view, device, group }) {
+function viewSetup({ view, device }) {
   if (view.index === 0) {
     view.scaleBy(0.6);
   } else if (view.index === 1) {

--- a/examples/projected.js
+++ b/examples/projected.js
@@ -12,7 +12,7 @@ const app = new WAMS.Application({
    * Mult-screen gestures are currently incomplatible with targetting different
    * drag events at different screens- all screens/views move together.
    */
-  // useMultiScreenGestures: true,
+  useMultiScreenGestures: true,
 });
 app.addStaticDirectory(path.join(__dirname, 'img'));
 
@@ -36,16 +36,25 @@ app.spawn(
   })
 );
 
+const viewGroup = app.createViewGroup();
+viewGroup.scaleBy(1.7);
+viewGroup.on('drag', WAMS.predefined.actions.drag);
+
 function viewSetup({ view, device }) {
   if (view.index === 0) {
     view.scaleBy(0.6);
   } else if (view.index === 1) {
-    view.on('drag', WAMS.predefined.actions.drag);
+    // With multi-device gestures, views are currently acted on as a group.
+    view.group.on('drag', WAMS.predefined.actions.drag);
     view.scaleBy(3.4);
     view.moveTo(1615, 2800);
   } else {
     view.scaleBy(1.7);
-    view.on('drag', WAMS.predefined.actions.drag);
+    // Connect all the rest of the views into one view group!
+    // - Multi-device gestures still won't work properly as the devices are
+    // layered on top of each other. The layouts currently don't support
+    // anything less than one group for all views/devices.
+    viewGroup.add(view);
   }
 }
 

--- a/examples/shared-polygons.js
+++ b/examples/shared-polygons.js
@@ -37,7 +37,7 @@ function spawnItem(event) {
   item.on('drag', WAMS.predefined.actions.drag);
 }
 
-const viewGroup = app.switchboard.group;
+const viewGroup = app.createViewGroup();
 viewGroup.on('click', spawnItem);
 viewGroup.on('pinch', WAMS.predefined.actions.pinch);
 viewGroup.on('rotate', WAMS.predefined.actions.rotate);
@@ -45,6 +45,7 @@ viewGroup.on('drag', WAMS.predefined.actions.drag);
 
 const line = new WAMS.predefined.layouts.Line(5);
 function handleConnect({ view, device }) {
+  viewGroup.add(view);
   line.layout(view, device);
 }
 

--- a/examples/walkthrough-paper.js
+++ b/examples/walkthrough-paper.js
@@ -16,10 +16,12 @@ function spawnSquare(event) {
   return item;
 }
 
-app.switchboard.group.on('click', spawnSquare);
+const viewGroup = app.createViewGroup();
+viewGroup.on('click', spawnSquare);
 
 const line = new Line(200);
 function handleConnect({ view, device }) {
+  viewGroup.add(view);
   line.layout(view, device);
 }
 

--- a/src/client/ClientElement.js
+++ b/src/client/ClientElement.js
@@ -66,9 +66,9 @@ class ClientElement extends WamsElement {
   }
 
   /**
-   * Set parent ServerGroup for the element.
+   * Set parent ServerItemGroup for the element.
    *
-   * @param {module:server:ServerGroup} parent server group for this element
+   * @param {module:server:ServerItemGroup} parent server group for this element
    */
   setParent(parent) {
     this.parent = parent;

--- a/src/client/ClientImage.js
+++ b/src/client/ClientImage.js
@@ -73,9 +73,9 @@ class ClientImage extends WamsImage {
   }
 
   /**
-   * Set parent ServerGroup for the image.
+   * Set parent ServerItemGroup for the image.
    *
-   * @param {module:server:ServerGroup} parent server group for this image
+   * @param {module:server:ServerItemGroup} parent server group for this image
    */
   setParent(parent) {
     this.parent = parent;

--- a/src/client/ClientItem.js
+++ b/src/client/ClientItem.js
@@ -41,9 +41,9 @@ class ClientItem extends Item {
   }
 
   /**
-   * Set parent ServerGroup for the item.
+   * Set parent ServerItemGroup for the item.
    *
-   * @param {module:server:ServerGroup} parent server group for this item
+   * @param {module:server:ServerItemGroup} parent server group for this item
    */
   setParent(parent) {
     this.parent = parent;

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -22,6 +22,9 @@ const MessageHandler = require('./MessageHandler.js');
  * @param {string} [settings.color='gray'] Background color for the workspace.
  * @param {boolean} [settings.useMultiScreenGestures=false] - Whether to use server-side gestures.
  * @param {boolean} [settings.applySmoothing=true] - Whether to apply smoothing to gesture inputs on coarse pointer devices (e.g. touch screens).
+ * @param {boolean} [settings.shadows=false] - Whether to show shadows of other views.
+ * @param {boolean} [settings.status=false] - Whether to show debugging status information in the view.
+ * @param {boolean} [settings.backgroundImage=undefined] - Optional background image for canvas.
  * @param {number} [clientLimit=10] - The number of active clients that are allowed
  * @param {express.app} [appRouter=predefined.routing.router()] - Route handler to use.
  * @param {http.Server} [server=http.createServer()] - HTTP server to use.
@@ -205,6 +208,9 @@ Application.DEFAULTS = Object.freeze({
   useMultiScreenGestures: false,
   applySmoothing: true,
   clientLimit: 10,
+  shadows: false,
+  status: false,
+  backgroundImage: undefined,
 });
 
 module.exports = Application;

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -187,8 +187,8 @@ class Application {
    *
    * @param  {obj} values properties for the group
    */
-  createGroup(values) {
-    return this.workspace.createGroup(values);
+  createItemGroup(values) {
+    return this.workspace.createItemGroup(values);
   }
 
   /**

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -193,10 +193,18 @@ class Application {
    * Create a group for existing items in the workspace.
    * A group allows to interact with several elements simultaneously.
    *
-   * @param  {obj} values properties for the group
+   * @param  {object} values properties for the group
    */
   createItemGroup(values) {
     return this.workspace.createItemGroup(values);
+  }
+
+  /**
+   * Create a group for views in the viewspace. The views in a group will be
+   * able to perform multi-device gestures together.
+   */
+  createViewGroup() {
+    return this.viewspace.createViewGroup();
   }
 
   /**

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -79,7 +79,7 @@ class Application {
      *
      * @type {module:server.MessageHandler}
      */
-    this.messageHandler = new MessageHandler(this, this.workspace);
+    this.messageHandler = new MessageHandler(this);
 
     /**
      * The switchboard allows communication with clients

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -11,6 +11,7 @@ const { constants, Message } = require('../shared.js');
 const { addStaticDirectory, getLocalIP, listen, router } = require('../predefined/routing.js');
 const Switchboard = require('./Switchboard.js');
 const WorkSpace = require('./WorkSpace.js');
+const ViewSpace = require('./ViewSpace.js');
 const MessageHandler = require('./MessageHandler.js');
 
 /**
@@ -76,7 +77,7 @@ class Application {
     this.settings = { ...Application.DEFAULTS, ...settings };
 
     /**
-     * The main model. The buck stops here.
+     * The main model for items.
      *
      * @type {module:server.WorkSpace}
      */
@@ -88,6 +89,13 @@ class Application {
      * @type {module:server.MessageHandler}
      */
     this.messageHandler = new MessageHandler(this);
+
+    /**
+     * The main model for views.
+     *
+     * @type {module:server.ViewSpace}
+     */
+    this.viewspace = new ViewSpace(this.messageHandler);
 
     /**
      * The switchboard allows communication with clients

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -20,10 +20,9 @@ const MessageHandler = require('./MessageHandler.js');
  *
  * @param {object} [settings={}] - Settings data to be forwarded to the server.
  * @param {string} [settings.color='gray'] Background color for the workspace.
- * @param {boolean} [settings.useMultiScreenGestures=false] - Whether to use
- * server-side gestures.
- * @param {boolean} [settings.applySmoothing=true] - Whether to apply smoothing
- * to gesture inputs on coarse pointer devices (e.g. touch screens).
+ * @param {boolean} [settings.useMultiScreenGestures=false] - Whether to use server-side gestures.
+ * @param {boolean} [settings.applySmoothing=true] - Whether to apply smoothing to gesture inputs on coarse pointer devices (e.g. touch screens).
+ * @param {number} [clientLimit=10] - The number of active clients that are allowed
  * @param {express.app} [appRouter=predefined.routing.router()] - Route handler to use.
  * @param {http.Server} [server=http.createServer()] - HTTP server to use.
  */
@@ -86,7 +85,7 @@ class Application {
      *
      * @type {module:server.Switchboard}
      */
-    this.switchboard = new Switchboard(this, this.namespace, settings);
+    this.switchboard = new Switchboard(this, this.namespace, settings.clientLimit);
   }
 
   /**
@@ -110,7 +109,7 @@ class Application {
    * listen.
    * @see module:server.Application~getLocalIP
    */
-  listen(port = Switchboard.DEFAULTS.port, host = '0.0.0.0') {
+  listen(port = 9000, host = '0.0.0.0') {
     listen(this.httpServer, host, port);
   }
 
@@ -205,6 +204,7 @@ Application.DEFAULTS = Object.freeze({
   color: '#dad1e3',
   useMultiScreenGestures: false,
   applySmoothing: true,
+  clientLimit: 10,
 });
 
 module.exports = Application;

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -19,6 +19,11 @@ const MessageHandler = require('./MessageHandler.js');
  * @memberof module:server
  *
  * @param {object} [settings={}] - Settings data to be forwarded to the server.
+ * @param {string} [settings.color='gray'] Background color for the workspace.
+ * @param {boolean} [settings.useMultiScreenGestures=false] - Whether to use
+ * server-side gestures.
+ * @param {boolean} [settings.applySmoothing=true] - Whether to apply smoothing
+ * to gesture inputs on coarse pointer devices (e.g. touch screens).
  * @param {express.app} [appRouter=predefined.routing.router()] - Route handler to use.
  * @param {http.Server} [server=http.createServer()] - HTTP server to use.
  */
@@ -56,11 +61,18 @@ class Application {
     this.namespace = this.ioServer.of(constants.NS_WAMS);
 
     /**
+     * Settings for the application.
+     *
+     * @type {object}
+     */
+    this.settings = { ...Application.DEFAULTS, ...settings };
+
+    /**
      * The main model. The buck stops here.
      *
      * @type {module:server.WorkSpace}
      */
-    this.workspace = new WorkSpace(settings, this.namespace);
+    this.workspace = new WorkSpace(this.namespace);
 
     /**
      * The MessageHandler responds to messages.
@@ -74,7 +86,7 @@ class Application {
      *
      * @type {module:server.Switchboard}
      */
-    this.switchboard = new Switchboard(this.workspace, this.messageHandler, this.namespace, settings);
+    this.switchboard = new Switchboard(this.workspace, this, this.messageHandler, this.namespace, settings);
   }
 
   /**
@@ -183,5 +195,16 @@ class Application {
 }
 
 Object.assign(Application.prototype, EventEmitter.prototype);
+
+/**
+ * The default values for an Application.
+ *
+ * @type {object}
+ */
+Application.DEFAULTS = Object.freeze({
+  color: '#dad1e3',
+  useMultiScreenGestures: false,
+  applySmoothing: true,
+});
 
 module.exports = Application;

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -94,7 +94,7 @@ class Application {
      *
      * @type {module:server.Switchboard}
      */
-    this.switchboard = new Switchboard(this, this.namespace, settings.clientLimit);
+    this.switchboard = new Switchboard(this, this.namespace, this.settings.clientLimit);
   }
 
   /**

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -86,7 +86,7 @@ class Application {
      *
      * @type {module:server.Switchboard}
      */
-    this.switchboard = new Switchboard(this.workspace, this, this.messageHandler, this.namespace, settings);
+    this.switchboard = new Switchboard(this, this.messageHandler, this.namespace, settings);
   }
 
   /**

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -19,13 +19,19 @@ const MessageHandler = require('./MessageHandler.js');
  * @memberof module:server
  *
  * @param {object} [settings={}] - Settings data to be forwarded to the server.
- * @param {string} [settings.color='gray'] Background color for the workspace.
- * @param {boolean} [settings.useMultiScreenGestures=false] - Whether to use server-side gestures.
- * @param {boolean} [settings.applySmoothing=true] - Whether to apply smoothing to gesture inputs on coarse pointer devices (e.g. touch screens).
+ * @param {boolean} [settings.applySmoothing=true] - Whether to apply smoothing
+ * to gesture inputs on coarse pointer devices (e.g. touch screens).
  * @param {boolean} [settings.shadows=false] - Whether to show shadows of other views.
  * @param {boolean} [settings.status=false] - Whether to show debugging status information in the view.
- * @param {boolean} [settings.backgroundImage=undefined] - Optional background image for canvas.
+ * @param {boolean} [settings.useMultiScreenGestures=false] - Whether to use server-side gestures.
+ * @param {string} [settings.backgroundImage=undefined] - Optional background image for canvas.
+ * Not recommended. Prefer defining your own HTML, CSS, server, and routing.
+ * @param {string} [settings.clientScripts=undefined] - Optional extra javascript to load in client.
+ * Not recommended. Prefer defining your own HTML, CSS, server, and routing.
+ * @param {string} [settings.color='gray'] Background color for the workspace.
+ * Not recommended. Prefer defining your own HTML, CSS, server, and routing.
  * @param {number} [clientLimit=10] - The number of active clients that are allowed
+ * Not recommended. Prefer defining your own HTML, CSS, server, and routing.
  * @param {express.app} [appRouter=predefined.routing.router()] - Route handler to use.
  * @param {http.Server} [server=http.createServer()] - HTTP server to use.
  */
@@ -204,13 +210,15 @@ Object.assign(Application.prototype, EventEmitter.prototype);
  * @type {object}
  */
 Application.DEFAULTS = Object.freeze({
-  color: '#dad1e3',
-  useMultiScreenGestures: false,
   applySmoothing: true,
+  backgroundImage: undefined,
   clientLimit: 10,
+  clientScripts: undefined,
+  color: '#dad1e3',
   shadows: false,
   status: false,
-  backgroundImage: undefined,
+  stylesheets: undefined,
+  useMultiScreenGestures: false,
 });
 
 module.exports = Application;

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -86,7 +86,7 @@ class Application {
      *
      * @type {module:server.Switchboard}
      */
-    this.switchboard = new Switchboard(this, this.messageHandler, this.namespace, settings);
+    this.switchboard = new Switchboard(this, this.namespace, settings);
   }
 
   /**

--- a/src/server/MessageHandler.js
+++ b/src/server/MessageHandler.js
@@ -43,16 +43,6 @@ class MessageHandler {
   }
 
   /**
-   * Send an event to the application
-   *
-   * @param {string} name
-   * @param {object} data
-   */
-  send(name, data) {
-    this.application.emit(name, data);
-  }
-
-  /**
    * Apply a click event
    *
    * @param {object} event

--- a/src/server/MessageHandler.js
+++ b/src/server/MessageHandler.js
@@ -6,11 +6,11 @@
  *
  * @memberof module:server
  *
- * @param {module:server.WorkSpace} workspace - the model used when responding
- * to messages.
+ * @param {module:server.Application} application - The WAMS application for
+ * this message handler.
  */
 class MessageHandler {
-  constructor(application, workspace) {
+  constructor(application) {
     /**
      * The Application to which this MessageHandler belongs.
      * @type {module:server.Application}
@@ -24,7 +24,7 @@ class MessageHandler {
      *
      * @type {module:server.WorkSpace}
      */
-    this.workspace = workspace;
+    this.workspace = application.workspace;
   }
 
   /**

--- a/src/server/ServerController.js
+++ b/src/server/ServerController.js
@@ -130,7 +130,7 @@ class ServerController {
       [Message.BLUR]: () => this.group.clearInputsFromView(this.view.id),
 
       [Message.DISPATCH]: (data) => {
-        this.messageHandler.send(data.action, { ...data.payload, view: this.view });
+        this.application.emit(data.action, { ...data.payload, view: this.view });
       },
     };
 
@@ -170,7 +170,7 @@ class ServerController {
     this.group.removeView(this.view);
     this.view.releaseLockedItem();
     this.socket.disconnect(true);
-    this.messageHandler.send('disconnect', {
+    this.application.emit('disconnect', {
       view: this.view,
       device: this.device,
       group: this.group,
@@ -188,7 +188,7 @@ class ServerController {
    */
   layout({ width, height }) {
     this.setSize(width, height);
-    this.messageHandler.send('connect', {
+    this.application.emit('connect', {
       view: this.view,
       device: this.device,
       group: this.group,

--- a/src/server/ServerController.js
+++ b/src/server/ServerController.js
@@ -11,25 +11,22 @@ const symbols = Object.freeze({
 
 /**
  * A ServerController maintains a socket.io connection between a client and the
- * server. It tracks a view associated with the client, as well as the
- * associated workspace.
+ * server. It tracks a view associated with the client.
  *
  * @memberof module:server
  *
  * @param {number} index - The index of this ServerController in the workspace,
  * can be used as a unique identifier.
  * @param {Socket} socket - A socket.io connection with a client.
- * @param {module:server.WorkSpace} workspace - The workspace associated with
- * this connection.
  * @param {module:server.Application} application - The WAMS application for
- * this controller..
+ * this controller.
  * @param {module:server.MessageHandler} messageHandler - For responding to
  * messages from clients.
  * @param {module:server.ServerViewGroup} group - The group to which this
  * connection will belong.
  */
 class ServerController {
-  constructor(index, socket, workspace, application, messageHandler, group) {
+  constructor(index, socket, application, messageHandler, group) {
     /**
      * The index is an integer identifying the ServerController, which can also
      * be used for locating the ServerController in a collection.
@@ -44,14 +41,6 @@ class ServerController {
      * @type {Socket}
      */
     this.socket = socket;
-
-    /**
-     * This is a shared reference to the single principle WorkSpace. Think of it
-     * like a 'parent' reference in a tree node.
-     *
-     * @type {module:server.WorkSpace}
-     */
-    this.workspace = workspace;
 
     /**
      * The WAMS application for this controller.
@@ -157,7 +146,7 @@ class ServerController {
     return {
       settings: this.application.settings,
       views: this.group.toJSON(),
-      items: this.workspace.toJSON(),
+      items: this.application.workspace.toJSON(),
       viewId: this.view.id,
     };
   }

--- a/src/server/ServerController.js
+++ b/src/server/ServerController.js
@@ -21,13 +21,15 @@ const symbols = Object.freeze({
  * @param {Socket} socket - A socket.io connection with a client.
  * @param {module:server.WorkSpace} workspace - The workspace associated with
  * this connection.
+ * @param {module:server.Application} application - The WAMS application for
+ * this controller..
  * @param {module:server.MessageHandler} messageHandler - For responding to
  * messages from clients.
  * @param {module:server.ServerViewGroup} group - The group to which this
  * connection will belong.
  */
 class ServerController {
-  constructor(index, socket, workspace, messageHandler, group) {
+  constructor(index, socket, workspace, application, messageHandler, group) {
     /**
      * The index is an integer identifying the ServerController, which can also
      * be used for locating the ServerController in a collection.
@@ -50,6 +52,13 @@ class ServerController {
      * @type {module:server.WorkSpace}
      */
     this.workspace = workspace;
+
+    /**
+     * The WAMS application for this controller.
+     *
+     * @type {module:server.Application}
+     */
+    this.application = application;
 
     /**
      * Responds to messages from clients.
@@ -146,7 +155,7 @@ class ServerController {
    */
   toJSON() {
     return {
-      settings: this.workspace.settings,
+      settings: this.application.settings,
       views: this.group.toJSON(),
       items: this.workspace.toJSON(),
       viewId: this.view.id,
@@ -215,7 +224,7 @@ class ServerController {
     event.x = x;
     event.y = y;
     this.view.emit(event.type, event);
-    if (this.workspace.settings.useMultiScreenGestures) {
+    if (this.application.settings.useMultiScreenGestures) {
       this.group.gestureController.process(event);
     }
   }

--- a/src/server/ServerController.js
+++ b/src/server/ServerController.js
@@ -20,13 +20,11 @@ const symbols = Object.freeze({
  * @param {Socket} socket - A socket.io connection with a client.
  * @param {module:server.Application} application - The WAMS application for
  * this controller.
- * @param {module:server.MessageHandler} messageHandler - For responding to
- * messages from clients.
  * @param {module:server.ServerViewGroup} group - The group to which this
  * connection will belong.
  */
 class ServerController {
-  constructor(index, socket, application, messageHandler, group) {
+  constructor(index, socket, application, group) {
     /**
      * The index is an integer identifying the ServerController, which can also
      * be used for locating the ServerController in a collection.
@@ -48,13 +46,6 @@ class ServerController {
      * @type {module:server.Application}
      */
     this.application = application;
-
-    /**
-     * Responds to messages from clients.
-     *
-     * @type {module:server.MessageHandler}
-     */
-    this.messageHandler = messageHandler;
 
     /**
      * Track the group to which this connection belongs.
@@ -94,7 +85,8 @@ class ServerController {
    * @memberof module:server.ServerController
    */
   [symbols.attachSocketIoListeners]() {
-    const handleGesture = this.messageHandler.handleGesture;
+    const messageHandler = this.application.messageHandler;
+    const handleGesture = messageHandler.handleGesture;
     const listeners = {
       // For the server to inform about changes to the model
       [Message.ADD_ELEMENT]: NOP,
@@ -119,11 +111,11 @@ class ServerController {
       [Message.LAYOUT]: this.layout.bind(this),
 
       // User event related
-      [Message.CLICK]: handleGesture.bind(this.messageHandler, 'click', this.view),
-      [Message.SWIPE]: handleGesture.bind(this.messageHandler, 'swipe', this.view),
-      [Message.TRANSFORM]: handleGesture.bind(this.messageHandler, 'transform', this.view),
+      [Message.CLICK]: handleGesture.bind(messageHandler, 'click', this.view),
+      [Message.SWIPE]: handleGesture.bind(messageHandler, 'swipe', this.view),
+      [Message.TRANSFORM]: handleGesture.bind(messageHandler, 'transform', this.view),
       [Message.RESIZE]: this.resize.bind(this),
-      [Message.TRACK]: (data) => this.messageHandler.track(data, this.view),
+      [Message.TRACK]: (data) => messageHandler.track(data, this.view),
 
       // Multi-device gesture related
       [Message.POINTER]: this.pointerEvent.bind(this),

--- a/src/server/ServerItemGroup.js
+++ b/src/server/ServerItemGroup.js
@@ -8,26 +8,26 @@ const { Hittable, Identifiable } = require('../mixins.js');
  * HACK to get around jsdoc bug that causes mixed methods and properties to be
  * duplicated.
  *
- * @class __ServerGroup
+ * @class __ServerItemGroup
  * @private
  * @mixes module:mixins.Hittable
  * @mixes module:mixins.Identifiable
  */
 
 /**
- * The ServerGroup provides operations for the server to locate and move
+ * The ServerItemGroup provides operations for the server to locate and move
  * several different elements around.
  *
  * @memberof module:server
  * @extends module:shared.WamsElement
- * @extends __ServerGroup
+ * @extends __ServerItemGroup
  *
  * @param {Namespace} namespace - Socket.io namespace for publishing changes.
  * @param {Object} values - User-supplied data detailing the elements.
  * Properties on this object that line up with {@link module:shared.Element}
  * members will be stored. Any other properties will be ignored.
  */
-class ServerGroup extends Identifiable(Hittable(Item)) {
+class ServerItemGroup extends Identifiable(Hittable(Item)) {
   constructor(namespace, values = {}) {
     super(values);
 
@@ -39,7 +39,7 @@ class ServerGroup extends Identifiable(Hittable(Item)) {
     this.namespace = namespace;
 
     // Notify subscribers immediately.
-    if (!this.items) throw Error('Items must be passed to ServerGroup.');
+    if (!this.items) throw Error('Items must be passed to ServerItemGroup.');
 
     // calculate based on elements positions;
     this.setMeasures();
@@ -108,6 +108,6 @@ class ServerGroup extends Identifiable(Hittable(Item)) {
   }
 }
 
-Object.assign(ServerGroup.prototype, EventEmitter.prototype);
+Object.assign(ServerItemGroup.prototype, EventEmitter.prototype);
 
-module.exports = ServerGroup;
+module.exports = ServerItemGroup;

--- a/src/server/ServerView.js
+++ b/src/server/ServerView.js
@@ -40,6 +40,14 @@ class ServerView extends Locker(Interactable(View)) {
     this.socket = socket;
 
     /**
+     * The group that this view belongs to.
+     *
+     * @type {module:server.ServerViewGroup}
+     * @default null
+     */
+    this.group = null;
+
+    /**
      * A place for user to store view state.
      */
     this.state = {};

--- a/src/server/ServerViewGroup.js
+++ b/src/server/ServerViewGroup.js
@@ -48,6 +48,30 @@ class ServerViewGroup extends Locker(Lockable(Transformable2D(View))) {
   }
 
   /**
+   * Add a view to this group.
+   *
+   * @param {module:server.ServerView} view - View to add.
+   */
+  add(view) {
+    if (view.group) {
+      view.group.remove(view);
+    }
+    this.views.push(view);
+    view.group = this;
+  }
+
+  /**
+   * Remove a view from this group.
+   *
+   * @param {module:server.ServerView} view - View to remove.
+   */
+  remove(view) {
+    this.clearInputsFromView(view.id);
+    view.group = null;
+    removeById(this.views, view);
+  }
+
+  /**
    * Clear the inputs associated with the given view from the gesture
    * controller.
    *
@@ -68,23 +92,6 @@ class ServerViewGroup extends Locker(Lockable(Transformable2D(View))) {
   moveBy(dx = 0, dy = 0) {
     super.moveBy(dx, dy);
     this.views.forEach((v) => v.moveBy(dx, dy));
-  }
-
-  /**
-   * Remove a view from the group.
-   *
-   * @param {module:server.ServerView} view - View to remove from the group.
-   */
-  removeView(view) {
-    removeById(this.views, view);
-    this.clearInputsFromView(view.id);
-  }
-
-  /**
-   * @return {module:shared.View[]} Serialize the views in this group.
-   */
-  toJSON() {
-    return this.views.map((v) => v.toJSON());
   }
 
   /*
@@ -118,17 +125,6 @@ class ServerViewGroup extends Locker(Lockable(Transformable2D(View))) {
   scaleBy(ds = 1, mx = this.x, my = this.y) {
     super.scaleBy(ds, mx, my, 'divideBy');
     this.views.forEach((v) => v.scaleBy(ds, mx, my));
-  }
-
-  /**
-   * Spawn a view into the group.
-   *
-   * @param {Namespace} socket - Socket.io socket for publishing changes.
-   */
-  spawnView(socket, index) {
-    const view = new ServerView(socket, { ...this, index });
-    this.views.push(view);
-    return view;
   }
 }
 

--- a/src/server/ServerViewGroup.js
+++ b/src/server/ServerViewGroup.js
@@ -94,19 +94,6 @@ class ServerViewGroup extends Locker(Lockable(Transformable2D(View))) {
     this.views.forEach((v) => v.moveBy(dx, dy));
   }
 
-  /**
-   * Move the transformable to the given coordinates.
-   *
-   * @override
-   *
-   * @param {number} [ x=this.x ] - x coordinate to move to.
-   * @param {number} [ y=this.y ] - y coordinate to move to.
-   */
-  moveTo(x = this.x, y = this.y) {
-    super.moveTo(x, y);
-    this.views.forEach((v) => v.moveTo(x, y));
-  }
-
   /*
    * Rotate all the views by the given amount, in radians.
    *

--- a/src/server/ServerViewGroup.js
+++ b/src/server/ServerViewGroup.js
@@ -94,6 +94,19 @@ class ServerViewGroup extends Locker(Lockable(Transformable2D(View))) {
     this.views.forEach((v) => v.moveBy(dx, dy));
   }
 
+  /**
+   * Move the transformable to the given coordinates.
+   *
+   * @override
+   *
+   * @param {number} [ x=this.x ] - x coordinate to move to.
+   * @param {number} [ y=this.y ] - y coordinate to move to.
+   */
+  moveTo(x = this.x, y = this.y) {
+    super.moveTo(x, y);
+    this.views.forEach((v) => v.moveTo(x, y));
+  }
+
   /*
    * Rotate all the views by the given amount, in radians.
    *

--- a/src/server/Switchboard.js
+++ b/src/server/Switchboard.js
@@ -55,6 +55,8 @@ function logConnection(id, status) {
  *
  * @param {module:server.WorkSpace} workspace - The workspace associated with
  * this connection.
+ * @param {module:server.Application} application - The WAMS application for
+ * this handler.
  * @param {module:server.MessageHandler} messageHandler - For responding to
  * messages from clients.
  * @param {Namespace} namespace - Socket.io namespace for publishing changes.
@@ -62,7 +64,7 @@ function logConnection(id, status) {
  * and workspace settings.
  */
 class Switchboard {
-  constructor(workspace, messageHandler, namespace, settings = {}) {
+  constructor(workspace, application, messageHandler, namespace, settings = {}) {
     /**
      * The number of active clients that are allowed at any given time.
      *
@@ -76,6 +78,13 @@ class Switchboard {
      * @type {module:server.WorkSpace}
      */
     this.workspace = workspace;
+
+    /**
+     * The WAMS application for this handler.
+     *
+     * @type {module:server.Application}
+     */
+    this.application = application;
 
     /**
      * The Message handler for responding to messages.
@@ -119,7 +128,14 @@ class Switchboard {
    */
   accept(socket) {
     const index = findEmptyIndex(this.connections);
-    const controller = new ServerController(index, socket, this.workspace, this.messageHandler, this.group);
+    const controller = new ServerController(
+      index,
+      socket,
+      this.workspace,
+      this.application,
+      this.messageHandler,
+      this.group
+    );
 
     this.connections[index] = controller;
     socket.on('disconnect', () => this.disconnect(controller));

--- a/src/server/Switchboard.js
+++ b/src/server/Switchboard.js
@@ -55,16 +55,16 @@ function logConnection(id, status) {
  * @param {module:server.Application} application - The WAMS application for
  * this handler.
  * @param {Namespace} namespace - Socket.io namespace for publishing changes.
- * @param {Object} settings - User-supplied options, specifying a client limit
+ * @param {number} clientLimit - The number of active clients that are allowed
  */
 class Switchboard {
-  constructor(application, namespace, settings = {}) {
+  constructor(application, namespace, clientLimit) {
     /**
      * The number of active clients that are allowed at any given time.
      *
      * @type {number}
      */
-    this.clientLimit = settings.clientLimit || Switchboard.DEFAULTS.clientLimit;
+    this.clientLimit = clientLimit;
 
     /**
      * The WAMS application for this handler.
@@ -161,15 +161,5 @@ class Switchboard {
     console.warn('Rejected incoming connection: client limit reached.');
   }
 }
-
-/**
- * The default values for the Switchboard.
- *
- * @type {object}
- */
-Switchboard.DEFAULTS = Object.freeze({
-  clientLimit: 1000,
-  port: 9000,
-});
 
 module.exports = Switchboard;

--- a/src/server/Switchboard.js
+++ b/src/server/Switchboard.js
@@ -48,36 +48,25 @@ function logConnection(id, status) {
 /**
  * A Switchboard handles the core server operations of a Wams program, including
  * server establishment, and establishing connections when new clients connect
- * to the server, as well as tracking the workspace associated with the server
- * so that connections can be linked to the workspace.
+ * to the server.
  *
  * @memberof module:server
  *
- * @param {module:server.WorkSpace} workspace - The workspace associated with
- * this connection.
  * @param {module:server.Application} application - The WAMS application for
  * this handler.
  * @param {module:server.MessageHandler} messageHandler - For responding to
  * messages from clients.
  * @param {Namespace} namespace - Socket.io namespace for publishing changes.
  * @param {Object} settings - User-supplied options, specifying a client limit
- * and workspace settings.
  */
 class Switchboard {
-  constructor(workspace, application, messageHandler, namespace, settings = {}) {
+  constructor(application, messageHandler, namespace, settings = {}) {
     /**
      * The number of active clients that are allowed at any given time.
      *
      * @type {number}
      */
     this.clientLimit = settings.clientLimit || Switchboard.DEFAULTS.clientLimit;
-
-    /**
-     * The principle workspace for this server.
-     *
-     * @type {module:server.WorkSpace}
-     */
-    this.workspace = workspace;
 
     /**
      * The WAMS application for this handler.
@@ -131,7 +120,6 @@ class Switchboard {
     const controller = new ServerController(
       index,
       socket,
-      this.workspace,
       this.application,
       this.messageHandler,
       this.group

--- a/src/server/Switchboard.js
+++ b/src/server/Switchboard.js
@@ -5,7 +5,6 @@ const { Message } = require('../shared.js');
 
 // Local project packages for the server.
 const ServerController = require('./ServerController.js');
-const ServerViewGroup = require('./ServerViewGroup.js');
 
 /**
  * Finds the first null or undefined index in the given array, and returns that
@@ -89,13 +88,6 @@ class Switchboard {
      */
     this.connections = [];
 
-    /**
-     * Track the active group.
-     *
-     * @type {module:server.ServerViewGroup}
-     */
-    this.group = new ServerViewGroup(this.application.messageHandler);
-
     // Automatically register a connection handler with the socket.io namespace.
     this.namespace.on('connect', this.connect.bind(this));
   }
@@ -108,7 +100,7 @@ class Switchboard {
    */
   accept(socket) {
     const index = findEmptyIndex(this.connections);
-    const controller = new ServerController(index, socket, this.application, this.group);
+    const controller = new ServerController(index, socket, this.application);
 
     this.connections[index] = controller;
     socket.on('disconnect', () => this.disconnect(controller));

--- a/src/server/Switchboard.js
+++ b/src/server/Switchboard.js
@@ -108,12 +108,7 @@ class Switchboard {
    */
   accept(socket) {
     const index = findEmptyIndex(this.connections);
-    const controller = new ServerController(
-      index,
-      socket,
-      this.application,
-      this.group
-    );
+    const controller = new ServerController(index, socket, this.application, this.group);
 
     this.connections[index] = controller;
     socket.on('disconnect', () => this.disconnect(controller));

--- a/src/server/Switchboard.js
+++ b/src/server/Switchboard.js
@@ -54,13 +54,11 @@ function logConnection(id, status) {
  *
  * @param {module:server.Application} application - The WAMS application for
  * this handler.
- * @param {module:server.MessageHandler} messageHandler - For responding to
- * messages from clients.
  * @param {Namespace} namespace - Socket.io namespace for publishing changes.
  * @param {Object} settings - User-supplied options, specifying a client limit
  */
 class Switchboard {
-  constructor(application, messageHandler, namespace, settings = {}) {
+  constructor(application, namespace, settings = {}) {
     /**
      * The number of active clients that are allowed at any given time.
      *
@@ -74,13 +72,6 @@ class Switchboard {
      * @type {module:server.Application}
      */
     this.application = application;
-
-    /**
-     * The Message handler for responding to messages.
-     *
-     * @type {module:server.MessageHandler}
-     */
-    this.messageHandler = messageHandler;
 
     /**
      * Socket.io namespace in which to operate.
@@ -103,7 +94,7 @@ class Switchboard {
      *
      * @type {module:server.ServerViewGroup}
      */
-    this.group = new ServerViewGroup(this.messageHandler);
+    this.group = new ServerViewGroup(this.application.messageHandler);
 
     // Automatically register a connection handler with the socket.io namespace.
     this.namespace.on('connect', this.connect.bind(this));
@@ -121,7 +112,6 @@ class Switchboard {
       index,
       socket,
       this.application,
-      this.messageHandler,
       this.group
     );
 

--- a/src/server/ViewSpace.js
+++ b/src/server/ViewSpace.js
@@ -37,6 +37,8 @@ class ViewSpace {
   }
 
   /**
+   * @memberof module:server.ViewSpace
+   *
    * @return {module:shared.View[]} Serialize the views in this group.
    */
   toJSON() {
@@ -45,6 +47,8 @@ class ViewSpace {
 
   /**
    * Remove a view from the viewspace.
+   *
+   * @memberof module:server.ViewSpace
    *
    * @param {module:server.ServerView} view - View to remove.
    */
@@ -62,6 +66,8 @@ class ViewSpace {
   /**
    * Spawn a view into the viewspace.
    *
+   * @memberof module:server.ViewSpace
+   *
    * @param {Namespace} socket - Socket.io socket for publishing changes.
    */
   spawnView(socket, index) {
@@ -71,6 +77,19 @@ class ViewSpace {
     this.views.push(view);
     group.add(view);
     return view;
+  }
+
+  /**
+   * Spawn a view group into the viewspace.
+   *
+   * @memberof module:server.ViewSpace
+   *
+   * @return {module:server.ServerViewGroup} The new view group.
+   */
+  createViewGroup() {
+    const group = new ServerViewGroup(this.messageHandler);
+    this.groups.push(group);
+    return group;
   }
 }
 

--- a/src/server/ViewSpace.js
+++ b/src/server/ViewSpace.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const { removeById } = require('../shared.js');
+const ServerViewGroup = require('./ServerViewGroup');
+const ServerView = require('./ServerView');
+
+/**
+ * The ViewSpace keeps track of views and view groups.
+ *
+ * @memberof module:server
+ *
+ * @param {module:server.MessageHandler} messageHandler - The message handler for
+ * this viewspace.
+ */
+class ViewSpace {
+  constructor(messageHandler) {
+    /**
+     * The views that are currently in this viewspace.
+     *
+     * @type {module:server.ServerView[]}
+     */
+    this.views = [];
+
+    /**
+     * The view groups that are currently in this viewspace.
+     *
+     * @type {module:server.ServerViewGroup[]}
+     */
+    this.groups = [];
+
+    /**
+     * The message handler for this viewspace.
+     *
+     * @type {module:server.MessageHandler}
+     */
+    this.messageHandler = messageHandler;
+  }
+
+  /**
+   * @return {module:shared.View[]} Serialize the views in this group.
+   */
+  toJSON() {
+    return this.views.map((v) => v.toJSON());
+  }
+
+  /**
+   * Remove a view from the viewspace.
+   *
+   * @param {module:server.ServerView} view - View to remove.
+   */
+  removeView(view) {
+    const group = view.group;
+    if (group) {
+      group.remove(view);
+      if (group.views.length === 0) {
+        removeById(this.groups, group);
+      }
+    }
+    removeById(this.views, view);
+  }
+
+  /**
+   * Spawn a view into the viewspace.
+   *
+   * @param {Namespace} socket - Socket.io socket for publishing changes.
+   */
+  spawnView(socket, index) {
+    const group = new ServerViewGroup(this.messageHandler);
+    this.groups.push(group);
+    const view = new ServerView(socket, { ...this, index });
+    this.views.push(view);
+    group.add(view);
+    return view;
+  }
+}
+
+module.exports = ViewSpace;

--- a/src/server/WorkSpace.js
+++ b/src/server/WorkSpace.js
@@ -213,7 +213,7 @@ class WorkSpace {
    *
    * @param {any} values properties for the group
    */
-  createGroup(values) {
+  createItemGroup(values) {
     const group = new ServerItemGroup(this.namespace, values);
     return this.addItem(group);
   }

--- a/src/server/WorkSpace.js
+++ b/src/server/WorkSpace.js
@@ -7,8 +7,8 @@ const ServerImage = require('./ServerImage.js');
 const ServerItem = require('./ServerItem.js');
 
 /**
- * The WorkSpace keeps track of views and items, and can handle events on
- * those items and views which allow them to be interacted with.
+ * The WorkSpace keeps track of items, and can handle events on those items
+ * which allow them to be interacted with.
  *
  * @memberof module:server
  *

--- a/src/server/WorkSpace.js
+++ b/src/server/WorkSpace.js
@@ -12,25 +12,10 @@ const ServerItem = require('./ServerItem.js');
  *
  * @memberof module:server
  *
- * @param {object} [settings] Options received from user.
- * @param {string} [settings.color='gray'] Background color for the workspace.
- * @param {boolean} [settings.useMultiScreenGestures=false] - Whether to use
- * server-side gestures. Default is to use client-side gestures.
  * @param {Namespace} namespace - Socket.io namespace for publishing changes.
  */
 class WorkSpace {
-  constructor(settings, namespace) {
-    /**
-     * Configuration settings for the workspace.
-     *
-     * @type {object}
-     * @property {string} [color='gray'] Background color for the workspace.
-     * @property {boolean} [settings.useMultiScreenGestures=false] Whether
-     * to use
-     * server-side gestures. Default is to use client-side gestures.
-     */
-    this.settings = { ...WorkSpace.DEFAULTS, ...settings };
-
+  constructor(namespace) {
     /**
      * Socket.io namespace in which to operate.
      *
@@ -233,16 +218,5 @@ class WorkSpace {
     return this.addItem(group);
   }
 }
-
-/**
- * The default values for a WorkSpace.
- *
- * @type {object}
- */
-WorkSpace.DEFAULTS = Object.freeze({
-  color: '#dad1e3',
-  useMultiScreenGestures: false,
-  applySmoothing: true,
-});
 
 module.exports = WorkSpace;

--- a/src/server/WorkSpace.js
+++ b/src/server/WorkSpace.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { removeById, Message } = require('../shared.js');
-const ServerGroup = require('./ServerGroup.js');
+const ServerItemGroup = require('./ServerItemGroup.js');
 const ServerElement = require('./ServerElement.js');
 const ServerImage = require('./ServerImage.js');
 const ServerItem = require('./ServerItem.js');
@@ -229,7 +229,7 @@ class WorkSpace {
    * @param {any} values properties for the group
    */
   createGroup(values) {
-    const group = new ServerGroup(this.namespace, values);
+    const group = new ServerItemGroup(this.namespace, values);
     return this.addItem(group);
   }
 }

--- a/tests/server/ServerViewGroup.test.js
+++ b/tests/server/ServerViewGroup.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { View } = require('shared.js');
+const Application = require('server/Application.js');
 const ServerViewGroup = require('server/ServerViewGroup.js');
 const ServerView = require('server/ServerView.js');
 const MessageHandler = require('server/MessageHandler.js');
@@ -8,11 +9,11 @@ const MessageHandler = require('server/MessageHandler.js');
 describe('ServerViewGroup', () => {
   describe('constructor(messageHandler)', () => {
     test('constructs correct type of object', () => {
-      expect(new ServerViewGroup(new MessageHandler())).toBeInstanceOf(ServerViewGroup);
+      expect(new ServerViewGroup(new MessageHandler(new Application()))).toBeInstanceOf(ServerViewGroup);
     });
 
     test('Uses defaults', () => {
-      expect(new ServerViewGroup(new MessageHandler())).toMatchObject({
+      expect(new ServerViewGroup(new MessageHandler(new Application()))).toMatchObject({
         views: expect.any(Array),
         x: 0,
         y: 0,
@@ -22,84 +23,6 @@ describe('ServerViewGroup', () => {
         scale: 1,
         type: 'view/background',
         index: undefined,
-      });
-    });
-  });
-
-  describe('Methods', () => {
-    let socket, viewGroup, view;
-    beforeAll(() => {
-      viewGroup = new ServerViewGroup(new MessageHandler());
-    });
-    beforeEach(() => {
-      socket = { emit: jest.fn() };
-    });
-
-    describe('spawnView(socket)', () => {
-      test('Returns a ServerView', () => {
-        expect(viewGroup.spawnView(socket)).toBeInstanceOf(ServerView);
-      });
-
-      test('Uses default View values', () => {
-        expect(viewGroup.spawnView(socket)).toMatchObject({
-          x: 0,
-          y: 0,
-          width: 1600,
-          height: 900,
-          rotation: 0,
-          scale: 1,
-          type: 'view/background',
-          index: undefined,
-        });
-      });
-
-      test('Keeps track of View', () => {
-        view = viewGroup.spawnView(socket);
-        expect(viewGroup.views).toContain(view);
-      });
-    });
-
-    describe('toJSON()', () => {
-      test('Returns an array', () => {
-        expect(viewGroup.toJSON()).toBeInstanceOf(Array);
-      });
-
-      test('Does not return the actual Views, but simple Objects', () => {
-        viewGroup.toJSON().forEach((v) => {
-          expect(v).not.toBeInstanceOf(ServerView);
-          expect(v).toBeInstanceOf(Object);
-        });
-      });
-
-      test('Objects returned contain only the expected data', () => {
-        viewGroup.toJSON().forEach((v) => {
-          expect(Object.getOwnPropertyNames(v)).toEqual(
-            expect.arrayContaining(['x', 'y', 'width', 'height', 'rotation', 'scale', 'type', 'index'])
-          );
-        });
-      });
-
-      test('Returns data for each View in the workspace', () => {
-        expect(viewGroup.toJSON().length).toBe(viewGroup.views.length);
-      });
-    });
-
-    describe('removeView(view)', () => {
-      test('Removes a view if it is found', () => {
-        expect(viewGroup.views).toContain(view);
-        expect(() => viewGroup.removeView(view)).not.toThrow();
-        expect(viewGroup.views).not.toContain(view);
-      });
-
-      test('Does not remove anything if view not found', () => {
-        const v = new ServerView({ x: 200, y: 200 });
-        const curr = Array.from(viewGroup.views);
-        expect(() => viewGroup.removeView(v)).not.toThrow();
-        expect(viewGroup.views).toEqual(curr);
-      });
-
-      test('Throws exception if not view provided', () => {
-        expect(() => viewGroup.removeView()).toThrow();
       });
     });
   });

--- a/tests/server/ViewSpace.test.js
+++ b/tests/server/ViewSpace.test.js
@@ -8,7 +8,6 @@ const ServerView = require('server/ServerView.js');
 const ViewSpace = require('server/ViewSpace.js');
 
 describe('ViewSpace', () => {
-
   describe('Methods', () => {
     let socket, viewspace, view;
     beforeEach(() => {

--- a/tests/server/ViewSpace.test.js
+++ b/tests/server/ViewSpace.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const { View } = require('shared.js');
+const Application = require('server/Application.js');
+const MessageHandler = require('server/MessageHandler.js');
+const ServerViewGroup = require('server/ServerViewGroup.js');
+const ServerView = require('server/ServerView.js');
+const ViewSpace = require('server/ViewSpace.js');
+
+describe('ViewSpace', () => {
+
+  describe('Methods', () => {
+    let socket, viewspace, view;
+    beforeEach(() => {
+      viewspace = new ViewSpace(new MessageHandler(new Application()));
+    });
+    beforeEach(() => {
+      socket = { emit: jest.fn() };
+    });
+
+    describe('spawnView(socket)', () => {
+      test('Returns a ServerView', () => {
+        expect(viewspace.spawnView(socket)).toBeInstanceOf(ServerView);
+      });
+
+      test('Uses default View values', () => {
+        expect(viewspace.spawnView(socket)).toMatchObject({
+          x: 0,
+          y: 0,
+          width: 1600,
+          height: 900,
+          rotation: 0,
+          scale: 1,
+          type: 'view/background',
+          index: undefined,
+        });
+      });
+
+      test('Keeps track of View', () => {
+        view = viewspace.spawnView(socket);
+        expect(viewspace.views).toContain(view);
+      });
+    });
+
+    describe('toJSON()', () => {
+      test('Returns an array', () => {
+        expect(viewspace.toJSON()).toBeInstanceOf(Array);
+      });
+
+      test('Does not return the actual Views, but simple Objects', () => {
+        viewspace.spawnView(socket);
+        viewspace.toJSON().forEach((v) => {
+          expect(v).not.toBeInstanceOf(ServerView);
+          expect(v).toBeInstanceOf(Object);
+        });
+      });
+
+      test('Objects returned contain only the expected data', () => {
+        viewspace.spawnView(socket);
+        viewspace.toJSON().forEach((v) => {
+          expect(Object.getOwnPropertyNames(v)).toEqual(
+            expect.arrayContaining(['x', 'y', 'width', 'height', 'rotation', 'scale', 'type', 'index'])
+          );
+        });
+      });
+
+      test('Returns data for each View in the workspace', () => {
+        viewspace.spawnView(socket);
+        viewspace.spawnView(socket);
+        viewspace.spawnView(socket);
+        expect(viewspace.toJSON().length).toBe(viewspace.views.length);
+      });
+    });
+
+    describe('removeView(view)', () => {
+      test('Removes a view if it is found', () => {
+        view = viewspace.spawnView(socket);
+        expect(viewspace.views).toContain(view);
+        expect(() => viewspace.removeView(view)).not.toThrow();
+        expect(viewspace.views).not.toContain(view);
+      });
+
+      test('Does not remove anything if view not found', () => {
+        view = viewspace.spawnView(socket);
+        const v = new ServerView({ x: 200, y: 200 });
+        const curr = Array.from(viewspace.views);
+        expect(() => viewspace.removeView(v)).not.toThrow();
+        expect(viewspace.views).toEqual(curr);
+      });
+
+      test('Throws exception if not view provided', () => {
+        expect(() => viewspace.removeView()).toThrow();
+      });
+    });
+  });
+});

--- a/tests/server/WorkSpace.test.js
+++ b/tests/server/WorkSpace.test.js
@@ -12,27 +12,6 @@ beforeAll(() => {
 });
 
 describe('WorkSpace', () => {
-  describe('constructor(port, settings)', () => {
-    test('constructs correct type of object', () => {
-      expect(new WorkSpace()).toBeInstanceOf(WorkSpace);
-    });
-
-    test('Uses default settings if none provided', () => {
-      expect(new WorkSpace().settings).toMatchObject(WorkSpace.DEFAULTS);
-    });
-
-    test('Uses user-defined settings, if provided', () => {
-      const custom = {
-        color: 'rgb(155,72, 84)',
-      };
-      expect(new WorkSpace(custom).settings).toMatchObject(custom);
-
-      const workspace = new WorkSpace({ color: 'a' });
-      expect(workspace.settings).not.toEqual(WorkSpace.DEFAULTS);
-      expect(workspace.settings.color).toEqual('a');
-    });
-  });
-
   describe('Methods', () => {
     let workspace;
     beforeAll(() => {


### PR DESCRIPTION
Differentiates between the Viewspace (a new class) and ServerViewGroups. This allows the creation of groups that are only a subset of the total number of views.
- The layouts don't yet support this. I think we need to incorporate layouts into ServerViewGroups and also have the ServerViewGroups or something similar track devices. Perhaps the view should know it's associated device.
- The related code and concepts may still need some iteration.

Includes a bit of cleanup to help with this:
- Rename ServerGroup -> ServerItemGroup
- Rename createGroup -> createItemGroup
- Attach settings to the Application instead of the workspace
- Store fewer references to the workspace
- Use application.emit directly instead of messageHandler.send
- Store fewer references to the MessageHandler
- Don't pass workspace into message handler separately
- Only pass the client limit, not all settings, to the switchboard
- Document more settings
- Fix formatting
- Sort and add warnings to settings
- Fix bug from not using `this.` before settings - missed default
- Remove commented-out line

Closes #62 
