### PR TITLE
Enhance ViewSpace concepts and allow line layout to operate on a subset of all views

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ function spawnSquare() {
   greenSquare.on('drag', actions.drag);
 }
 
-const line = new layouts.Line(300); // 300px overlap betweens views
+const line = new layouts.LineLayout(300); // 300px overlap betweens views
 
 function handleConnect({ view, device }) {
   view.on('click', spawnSquare);
@@ -432,7 +432,7 @@ By default, every connected screen is positioned in the same location and can se
 
 There are currently two predefined layouts: `table` and `line`.
 
-**`Table`**
+**`TableLayout`**
 
 Places users around a table, with the given amount of overlap. The first user will be the "table", and their position when they join is stamped as the outline of the table. The next four users are positioned, facing inwards, around the four sides of the table.
 
@@ -451,7 +451,7 @@ app.on('connect', handleConnect);
 
 To see this layout in action, check out the `card-table.js` example.
 
-**`Line`**
+**`LineLayout`**
 
 Places users in a line, with the given amount of overlap. Best used with either multi-screen gestures or when users are unable to manipulate their views.
 
@@ -459,10 +459,10 @@ Places users in a line, with the given amount of overlap. Best used with either 
 // application config should include
 // "useMultiScreenGestures: true"
 
-const { Line } = WAMS.predefined.layouts;
+const { LineLayout } = WAMS.predefined.layouts;
 
 const overlap = 200; // 200px overlap between screens
-const line = new Line(overlap);
+const line = new LineLayout(overlap);
 
 function handleConnect({ view, device }) {  // note the {} brackets to destructure the event object
   line.layout(view, device);

--- a/examples/card-table.js
+++ b/examples/card-table.js
@@ -198,7 +198,7 @@ function flipCard(event) {
   card.isFaceUp = !card.isFaceUp;
 }
 
-const table = new WAMS.predefined.layouts.Table(20);
+const table = new WAMS.predefined.layouts.TableLayout(20);
 app.on('connect', ({ view, device }) => table.layout(view, device));
 app.listen(9000);
 

--- a/examples/pick-n-drop.js
+++ b/examples/pick-n-drop.js
@@ -1,7 +1,7 @@
 const WAMS = require('..');
 const path = require('path');
 const { image } = WAMS.predefined.items;
-const { Line } = WAMS.predefined.layouts;
+const { LineLayout } = WAMS.predefined.layouts;
 
 const dimensions = [];
 const deepSpace = { x: 99999, y: 99999 };
@@ -29,7 +29,7 @@ app.on('deviceFarFromScreens', (data) => {
   if (currentView) moveScreenWithItems(currentView, deepSpace.x, deepSpace.y);
 });
 
-const line = new Line(0);
+const line = new LineLayout(0);
 function handleConnect({ view, device }) {
   if (view.index >= 2) {
     // send to deep space :)

--- a/examples/projected.js
+++ b/examples/projected.js
@@ -36,9 +36,12 @@ app.spawn(
   })
 );
 
+const lineLayout = new WAMS.predefined.layouts.LineLayout(5);
 const viewGroup = app.createViewGroup();
 viewGroup.scaleBy(1.7);
 viewGroup.on('drag', WAMS.predefined.actions.drag);
+viewGroup.on('pinch', WAMS.predefined.actions.pinch);
+viewGroup.on('rotate', WAMS.predefined.actions.rotate);
 
 function viewSetup({ view, device }) {
   if (view.index === 0) {
@@ -46,15 +49,17 @@ function viewSetup({ view, device }) {
   } else if (view.index === 1) {
     // With multi-device gestures, views are currently acted on as a group.
     view.group.on('drag', WAMS.predefined.actions.drag);
-    view.scaleBy(3.4);
+    // This only works because when views are created they are created with a
+    // new group, so we know we are not adding any other views to this group,
+    // and that we are not applying this scale multiple times to the same
+    // group, even if a view is disconnected and reconnected.
+    view.group.scaleBy(3.4);
     view.moveTo(1615, 2800);
   } else {
     view.scaleBy(1.7);
     // Connect all the rest of the views into one view group!
-    // - Multi-device gestures still won't work properly as the devices are
-    // layered on top of each other. The layouts currently don't support
-    // anything less than one group for all views/devices.
     viewGroup.add(view);
+    lineLayout.layout(view, device);
   }
 }
 

--- a/examples/shared-polygons.js
+++ b/examples/shared-polygons.js
@@ -43,7 +43,7 @@ viewGroup.on('pinch', WAMS.predefined.actions.pinch);
 viewGroup.on('rotate', WAMS.predefined.actions.rotate);
 viewGroup.on('drag', WAMS.predefined.actions.drag);
 
-const line = new WAMS.predefined.layouts.Line(5);
+const line = new WAMS.predefined.layouts.LineLayout(5);
 function handleConnect({ view, device }) {
   viewGroup.add(view);
   line.layout(view, device);

--- a/examples/swipe-drawing.js
+++ b/examples/swipe-drawing.js
@@ -37,7 +37,7 @@ function handleDrag({ x, y, dx, dy }) {
       rotation: Math.atan2(dx, dy),
     })
   );
-  // console.log('Line: { x: %s, y: %s, length: %s, rotation: %s }', line.x, line.y, length, line.rotation);
+  // console.log('LineLayout: { x: %s, y: %s, length: %s, rotation: %s }', line.x, line.y, length, line.rotation);
   setTimeout(() => app.removeItem(line), 3000);
 }
 

--- a/examples/walkthrough-paper.js
+++ b/examples/walkthrough-paper.js
@@ -6,7 +6,7 @@ const app = new WAMS.Application({
 });
 
 const { square } = WAMS.predefined.items;
-const { Line } = WAMS.predefined.layouts;
+const { LineLayout } = WAMS.predefined.layouts;
 
 function spawnSquare(event) {
   const item = app.spawn(square(event.x - 50, event.y - 50, 100, 'green'));
@@ -19,7 +19,7 @@ function spawnSquare(event) {
 const viewGroup = app.createViewGroup();
 viewGroup.on('click', spawnSquare);
 
-const line = new Line(200);
+const line = new LineLayout(200);
 function handleConnect({ view, device }) {
   viewGroup.add(view);
   line.layout(view, device);

--- a/src/mixins/Lockable.js
+++ b/src/mixins/Lockable.js
@@ -60,11 +60,11 @@ const Lockable = (superclass) =>
      * @memberof module:mixins.Lockable
      */
     unlock() {
-      this[locked] = false;
       if (this[holder] && this[holder].lockedItem === this) {
         this[holder].clearLockedItem();
-        this[holder] = null;
       }
+      this[locked] = false;
+      this[holder] = null;
     }
   };
 

--- a/src/mixins/Locker.js
+++ b/src/mixins/Locker.js
@@ -38,12 +38,23 @@ const Locker = (superclass) =>
      * Clear the locked item. Shortcuts the releaseLockedItem() approach and just
      * sets the locked item to null. Use with caution!
      *
-     * Made available originally purely for use by the Lockable interface.
-     *
      * @memberof module:mixins.Locker
+     * @private
      */
     clearLockedItem() {
       this[lockedItem] = null;
+    }
+
+    /**
+     * Set the locked item. Use with caution!
+     *
+     * @memberof module:mixins.Locker
+     * @private
+     *
+     * @param {module:mixins.Lockable} item - The item to lock down.
+     */
+    setLockedItem(item) {
+      this[lockedItem] = item;
     }
 
     /**
@@ -52,13 +63,16 @@ const Locker = (superclass) =>
      * @memberof module:mixins.Locker
      *
      * @param {module:mixins.Lockable} item - The item to lock down.
+     * @returns {boolean} True if the lock was obtained, false otherwise.
      */
     obtainLockOnItem(item) {
-      if (!item.isLocked()) {
-        if (this[lockedItem]) this[lockedItem].unlock();
-        this[lockedItem] = item;
-        item.lock(this);
+      if (item.isLocked()) {
+        return false;
       }
+      if (this[lockedItem]) this[lockedItem].unlock();
+      item.lock(this);
+      this.setLockedItem(item);
+      return true;
     }
 
     /**
@@ -68,7 +82,7 @@ const Locker = (superclass) =>
      */
     releaseLockedItem() {
       if (this[lockedItem]) this[lockedItem].unlock();
-      this[lockedItem] = null;
+      this.clearLockedItem();
     }
   };
 

--- a/src/predefined/layouts.js
+++ b/src/predefined/layouts.js
@@ -19,7 +19,7 @@ const { constants } = require('../shared.js');
  *
  * @param {number} overlap
  */
-class Table {
+class TableLayout {
   TABLE = 0;
   BOTTOM = 1;
   LEFT = 2;
@@ -29,7 +29,7 @@ class Table {
   constructor(overlap) {
     if (overlap == undefined) {
       // or if overlap is null, since using == instead of ===
-      throw new Error('overlap must be defined for Table layout');
+      throw new Error('Overlap must be defined for TableLayout.');
     }
     this.overlap = overlap;
     this.table = null;
@@ -117,11 +117,11 @@ class Table {
  *
  * @param {number} overlap
  */
-class Line {
+class LineLayout {
   constructor(overlap) {
     if (overlap == undefined) {
       // or if overlap is null, since using == instead of ===
-      throw new Error('overlap must be defined for Line layout');
+      throw new Error('Overlap must be defined for LineLayout.');
     }
     this.overlap = overlap;
     this.views = [];
@@ -153,28 +153,28 @@ class Line {
 /**
  * @deprecated
  * @param {number} overlap
- * @returns {Table}
+ * @returns {TableLayout}
  * @memberof module:predefined.layouts
  */
 function table(overlap) {
-  console.warn('WARNING: `table(overlap)` is deprecated, use `new Table(overlap)` instead.');
-  return new Table(overlap);
+  console.warn('WARNING: `table(overlap)` is deprecated, use `new TableLayout(overlap)` instead.');
+  return new TableLayout(overlap);
 }
 
 /**
  * @deprecated
  * @param {number} overlap
- * @returns {Line}
+ * @returns {LineLayout}
  * @memberof module:predefined.layouts
  */
 function line(overlap) {
-  console.warn('WARNING: `line(overlap)` is deprecated, use `new Line(overlap)` instead.');
-  return new Line(overlap);
+  console.warn('WARNING: `line(overlap)` is deprecated, use `new LineLayout(overlap)` instead.');
+  return new LineLayout(overlap);
 }
 
 module.exports = {
-  Line,
-  Table,
+  LineLayout,
+  TableLayout,
   line,
   table,
 };

--- a/src/predefined/layouts.js
+++ b/src/predefined/layouts.js
@@ -129,24 +129,25 @@ class LineLayout {
   }
 
   layout(view, device) {
-    if (view.index > 0) {
-      if (this.views[view.index - 1] == null) {
-        setTimeout(this.layout.bind(this, view, device), 0);
-      } else {
-        const prev = this.views[view.index - 1];
-        const change = prev.transformPointChange(this.overlap, 0);
-        const anchor = prev.topRight.minus(change);
-        view.moveTo(anchor.x, anchor.y);
+    if (this.views.length > 0) {
+      const prev = this.views[this.views.length - 1];
+      const change = prev.transformPointChange(this.overlap, 0);
+      const anchor = prev.topRight.minus(change);
+      view.moveTo(anchor.x, anchor.y);
 
-        const side = this.deviceRights[view.index - 1] - this.overlap;
-        device.moveTo(side, 0);
-        this.deviceRights[view.index] = side + device.width;
-        this.views[view.index] = view;
-      }
+      const side = this.deviceRights[this.deviceRights.length - 1] - this.overlap;
+      device.moveTo(side, 0);
+      this.deviceRights.push(side + device.width);
+      this.views.push(view);
     } else {
       this.deviceRights[0] = device.width;
       this.views[0] = view;
     }
+    view.on('disconnected', () => {
+      const index = this.views.indexOf(view);
+      this.views.splice(index, 1);
+      this.deviceRights.splice(index, 1);
+    });
   }
 }
 

--- a/src/server/Device.js
+++ b/src/server/Device.js
@@ -11,6 +11,17 @@ const { Transformable2D } = require('../mixins.js');
  * @extends module:shared.View
  * @mixes module:mixins.Transformable2D
  */
-class Device extends Transformable2D(View) {}
+class Device extends Transformable2D(View) {
+  constructor(values = {}) {
+    super(values);
+
+    /**
+     * The view that this device is attached to.
+     *
+     * @type {module:server.ServerView}
+     */
+    this.view = null;
+  }
+}
 
 module.exports = Device;

--- a/src/server/ServerController.js
+++ b/src/server/ServerController.js
@@ -196,8 +196,6 @@ class ServerController {
    * @param {PointerEvent} event - The event to forward.
    */
   pointerEvent(event) {
-    event.target = this.view.group;
-    event.view = this.view;
     event.source = this.view.id;
     event.pointerId = `${String(this.view.id)}-${event.pointerId}`;
 
@@ -211,6 +209,8 @@ class ServerController {
     event.clientY = viewPoint.y;
     event.x = viewPoint.x;
     event.y = viewPoint.y;
+    event.target = this.view;
+    event.view = this.view;
     this.view.emit(event.type, event);
 
     if (this.application.settings.useMultiScreenGestures) {
@@ -221,6 +221,8 @@ class ServerController {
       event.clientY = devicePoint.y;
       event.x = devicePoint.x;
       event.y = devicePoint.y;
+      event.target = this.view.group;
+      event.view = this.view.group;
       this.view.group.gestureController.process(event);
     }
   }

--- a/src/server/ServerController.js
+++ b/src/server/ServerController.js
@@ -209,6 +209,7 @@ class ServerController {
     event.clientY = viewPoint.y;
     event.x = viewPoint.x;
     event.y = viewPoint.y;
+    // Raw pointer events should directly target the view
     event.target = this.view;
     event.view = this.view;
     this.view.emit(event.type, event);
@@ -221,6 +222,7 @@ class ServerController {
       event.clientY = devicePoint.y;
       event.x = devicePoint.x;
       event.y = devicePoint.y;
+      // Multi-device gestures should target the view group
       event.target = this.view.group;
       event.view = this.view.group;
       this.view.group.gestureController.process(event);

--- a/src/server/ServerController.js
+++ b/src/server/ServerController.js
@@ -67,6 +67,11 @@ class ServerController {
      */
     this.device = new Device();
 
+    // Set up the view and device to reference each other. This will be very
+    // useful for layouts, etc.
+    this.view.device = this.device;
+    this.device.view = this.view;
+
     /*
      * Automatically begin operations by registering Message listeners and
      * Informing the client on the current state of the model.

--- a/src/server/ServerView.js
+++ b/src/server/ServerView.js
@@ -4,7 +4,7 @@ const { EventEmitter } = require('node:events');
 const { IdStamper, Message, View } = require('../shared.js');
 const { Interactable, Locker } = require('../mixins.js');
 
-const STAMPER = new IdStamper();
+const SERVER_VIEW_IDS = new IdStamper();
 
 /**
  * HACK to get around jsdoc bug that causes mixed methods and properties to be
@@ -68,7 +68,7 @@ class ServerView extends Locker(Interactable(View)) {
      * @instance
      * @memberof module:server.ServerView
      */
-    STAMPER.stampNewId(this);
+    SERVER_VIEW_IDS.stampNewId(this);
   }
 
   /**

--- a/src/server/ServerView.js
+++ b/src/server/ServerView.js
@@ -17,7 +17,7 @@ const STAMPER = new IdStamper();
  */
 
 /**
- * The ServerView provides operations for the server to locate, move, and
+ * The ServerView models an attached client view in the browser.
  * rescale views.
  *
  * @memberof module:server
@@ -46,6 +46,13 @@ class ServerView extends Locker(Interactable(View)) {
      * @default null
      */
     this.group = null;
+
+    /**
+     * The device corresponding to the client's device's physical orientation.
+     *
+     * @type {module:server.Device}
+     */
+    this.device = null;
 
     /**
      * A place for user to store view state.

--- a/src/server/ServerViewGroup.js
+++ b/src/server/ServerViewGroup.js
@@ -21,7 +21,13 @@ const SERVER_VIEW_GROUP_IDS = new IdStamper();
 
 /**
  * The ServerViewGroup groups a number of ServerViews together into a single
- * View, so that they can move together as one block.
+ * View, so that they can move together as one block. It is also responsible for
+ * interacting with the gesture handler.
+ *
+ * Each view always belongs to exactly one view group. The group is responsible
+ * for processing gestures for that view. In the case of multi-device gestures,
+ * the inputs to those gestures can come from many views, but are combined
+ * together into a single gesture response.
  *
  * @memberof module:server
  * @extends module:server.View

--- a/src/server/ServerViewGroup.js
+++ b/src/server/ServerViewGroup.js
@@ -151,6 +151,28 @@ class ServerViewGroup extends Locker(Lockable(Transformable2D(View))) {
     super.setLockedItem(item);
     this.views.forEach((v) => v.setLockedItem(item));
   }
+
+  /*
+   * Lock this view group.
+   *
+   * @override
+   *
+   * @param {module:mixins.Locker} locker - The holder of the lock.
+   */
+  lock(locker) {
+    super.lock(locker);
+    this.views.forEach((v) => v.lock(locker));
+  }
+
+  /*
+   * Unlock this view group.
+   *
+   * @override
+   */
+  unlock() {
+    super.unlock();
+    this.views.forEach((v) => v.unlock());
+  }
 }
 
 Object.assign(ServerViewGroup.prototype, EventEmitter.prototype);

--- a/src/server/ServerViewGroup.js
+++ b/src/server/ServerViewGroup.js
@@ -126,6 +126,31 @@ class ServerViewGroup extends Locker(Lockable(Transformable2D(View))) {
     super.scaleBy(ds, mx, my, 'divideBy');
     this.views.forEach((v) => v.scaleBy(ds, mx, my));
   }
+
+  /*
+   * Clear the locked item. Shortcuts the releaseLockedItem() approach and just
+   * sets the locked item to null. Use with caution!
+   *
+   * @override
+   * @private
+   */
+  clearLockedItem() {
+    super.clearLockedItem();
+    this.views.forEach((v) => v.clearLockedItem());
+  }
+
+  /*
+   * Set the locked item. Use with caution!
+   *
+   * @override
+   * @private
+   *
+   * @param {module:mixins.Lockable} item - The item to lock down.
+   */
+  setLockedItem(item) {
+    super.setLockedItem(item);
+    this.views.forEach((v) => v.setLockedItem(item));
+  }
 }
 
 Object.assign(ServerViewGroup.prototype, EventEmitter.prototype);

--- a/src/server/ServerViewGroup.js
+++ b/src/server/ServerViewGroup.js
@@ -3,8 +3,10 @@
 const { EventEmitter } = require('node:events');
 const GestureController = require('./GestureController.js');
 const ServerView = require('./ServerView.js');
-const { removeById, View } = require('../shared.js');
+const { IdStamper, removeById, View } = require('../shared.js');
 const { Lockable, Transformable2D, Locker } = require('../mixins.js');
+
+const SERVER_VIEW_GROUP_IDS = new IdStamper();
 
 /**
  * HACK to get around jsdoc bug that causes mixed methods and properties to be
@@ -45,6 +47,17 @@ class ServerViewGroup extends Locker(Lockable(Transformable2D(View))) {
      * @type {module:server.ServerView[]}
      */
     this.views = [];
+
+    /**
+     * Id to make the view groups uniquely identifiable.
+     *
+     * @name id
+     * @type {number}
+     * @constant
+     * @instance
+     * @memberof module:server.ServerView
+     */
+    SERVER_VIEW_GROUP_IDS.stampNewId(this);
   }
 
   /**

--- a/src/server/ViewSpace.js
+++ b/src/server/ViewSpace.js
@@ -61,6 +61,7 @@ class ViewSpace {
       }
     }
     removeById(this.views, view);
+    view.emit('disconnected');
   }
 
   /**


### PR DESCRIPTION
- Set up ServerView and Device to cross-reference each other
- Properly support locking/unlocking of items in the view group
- Properly support a view group being locked/unlocked
- Assign unique ids to server view groups
- Add to docs to clarify view group's responsibilities
- Don't let raw pointer events know about the view groups
- Add "Layout" suffix to layout classes
- Allow line layout to operate without needing to know the view's index
- Emit an event on the view when it is disconnected
- Enhance projected example to properly work with multi-device gestures
