### PR TITLE
Remove useMultiScreenGestures option as they are technically always on now

### DIFF
--- a/examples/projected.js
+++ b/examples/projected.js
@@ -6,14 +6,7 @@ const { image } = WAMS.predefined.items;
 const TOTAL_WIDTH = 5650;
 const TOTAL_HEIGHT = 6053;
 
-const app = new WAMS.Application({
-  shadows: true,
-  /*
-   * Mult-screen gestures are currently incomplatible with targetting different
-   * drag events at different screens- all screens/views move together.
-   */
-  useMultiScreenGestures: true,
-});
+const app = new WAMS.Application({ shadows: true });
 app.addStaticDirectory(path.join(__dirname, 'img'));
 
 app.on('position', (data) => {
@@ -57,7 +50,9 @@ function viewSetup({ view, device }) {
     view.moveTo(1615, 2800);
   } else {
     view.scaleBy(1.7);
-    // Connect all the rest of the views into one view group!
+    // Connect all the rest of the views into one view group! This has the
+    // effect of making the views act as one view, including combining their
+    // inputs into multi-device gestures!
     viewGroup.add(view);
     lineLayout.layout(view, device);
   }

--- a/examples/shared-polygons.js
+++ b/examples/shared-polygons.js
@@ -7,7 +7,6 @@
 
 const WAMS = require('..');
 const app = new WAMS.Application({
-  useMultiScreenGestures: true, // enables multi-screen gestures
   shadows: true,
   status: true,
 });
@@ -45,6 +44,9 @@ viewGroup.on('drag', WAMS.predefined.actions.drag);
 
 const line = new WAMS.predefined.layouts.LineLayout(0);
 function handleConnect({ view, device }) {
+  // Connect all the rest of the views into one view group! This has the effect
+  // of making the views act as one view, including combining their inputs into
+  // multi-device gestures!
   viewGroup.add(view);
   line.layout(view, device);
 }

--- a/examples/walkthrough-paper.js
+++ b/examples/walkthrough-paper.js
@@ -1,26 +1,27 @@
 const WAMS = require('..');
 const app = new WAMS.Application({
-  useMultiScreenGestures: true,
   shadows: true,
   status: true,
 });
 
-const { square } = WAMS.predefined.items;
-const { LineLayout } = WAMS.predefined.layouts;
+const { action, items, layouts } = WAMS.predefined;
 
 function spawnSquare(event) {
-  const item = app.spawn(square(100, 'green', { x: event.x, y: event.y }));
-  item.on('drag', WAMS.predefined.actions.drag);
-  item.on('rotate', WAMS.predefined.actions.rotate);
-  item.on('pinch', WAMS.predefined.actions.pinch);
+  const item = app.spawn(items.square(100, 'green', { x: event.x, y: event.y }));
+  item.on('drag', actions.drag);
+  item.on('rotate', actions.rotate);
+  item.on('pinch', actions.pinch);
   return item;
 }
 
 const viewGroup = app.createViewGroup();
 viewGroup.on('click', spawnSquare);
 
-const line = new LineLayout(0);
+const line = new layouts.LineLayout(0);
 function handleConnect({ view, device }) {
+  // Connect all the rest of the views into one view group! This has the effect
+  // of making the views act as one view, including combining their inputs into
+  // multi-device gestures!
   viewGroup.add(view);
   line.layout(view, device);
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { CanvasSequence } = require('canvas-sequencer');
-const { colours, Circle, Oval, Rectangle, Polygon2D } = require('./src/shared.js');
+const { colours, Circle, Oval, Rectangle, Polygon2D, RoundedLine } = require('./src/shared.js');
 const { Application } = require('./src/server.js');
 const predefined = require('./src/predefined.js');
 
@@ -12,6 +12,7 @@ module.exports = {
   Circle,
   Oval,
   Rectangle,
+  RoundedLine,
   Polygon2D,
   Application,
 };

--- a/src/server/Application.js
+++ b/src/server/Application.js
@@ -24,7 +24,6 @@ const MessageHandler = require('./MessageHandler.js');
  * to gesture inputs on coarse pointer devices (e.g. touch screens).
  * @param {boolean} [settings.shadows=false] - Whether to show shadows of other views.
  * @param {boolean} [settings.status=false] - Whether to show debugging status information in the view.
- * @param {boolean} [settings.useMultiScreenGestures=false] - Whether to use server-side gestures.
  * @param {string} [settings.backgroundImage=undefined] - Optional background image for canvas.
  * Not recommended. Prefer defining your own HTML, CSS, server, and routing.
  * @param {string} [settings.clientScripts=undefined] - Optional extra javascript to load in client.
@@ -234,7 +233,6 @@ Application.DEFAULTS = Object.freeze({
   shadows: false,
   status: false,
   stylesheets: undefined,
-  useMultiScreenGestures: false,
 });
 
 module.exports = Application;

--- a/src/server/ServerController.js
+++ b/src/server/ServerController.js
@@ -165,6 +165,7 @@ class ServerController {
     this.application.emit('disconnect', {
       view: this.view,
       device: this.device,
+      group: this.view.group,
     });
     return true;
   }
@@ -182,6 +183,7 @@ class ServerController {
     this.application.emit('connect', {
       view: this.view,
       device: this.device,
+      group: this.view.group,
     });
     this.socket.broadcast.emit(Message.ADD_SHADOW, this.view);
     this.socket.emit(Message.UD_VIEW, this.view);


### PR DESCRIPTION
All gestures are processed on the server now, organized via view groups. So to start using multi-device gestures, just add multiple views to a single group.
- It would probably be a good idea to position the views and their devices appropriately, but it's not necessary.

This also includes a bit of other cleanup and some fixes to the readme.