### PR TITLE
General cleanup around gestures and items

### DIFF
--- a/examples/swipe-drawing.js
+++ b/examples/swipe-drawing.js
@@ -38,7 +38,7 @@ function handleDrag({ x, y, dx, dy }) {
     })
   );
   // console.log('LineLayout: { x: %s, y: %s, length: %s, rotation: %s }', line.x, line.y, length, line.rotation);
-  setTimeout(() => app.removeItem(line), 3000);
+  setTimeout(() => app.removeItem(line), 500);
 }
 
 function handleConnect({ view }) {

--- a/src/client/ClientItem.js
+++ b/src/client/ClientItem.js
@@ -1,17 +1,17 @@
 'use strict';
 
-const { Item } = require('../shared.js');
+const { CanvasItem } = require('../shared.js');
 const { CanvasSequence } = require('canvas-sequencer');
 
 /**
  * The ClientItem class exposes the draw() funcitonality of wams items.
  *
- * @extends module:shared.Item
+ * @extends module:shared.CanvasItem
  * @memberof module:client
  *
- * @param {module:shared.Item} data - The data from the server describing this item.
+ * @param {module:shared.CanvasItem} data - The data from the server describing this item.
  */
-class ClientItem extends Item {
+class ClientItem extends CanvasItem {
   constructor(data) {
     super(data);
 

--- a/src/server/GestureController.js
+++ b/src/server/GestureController.js
@@ -63,7 +63,7 @@ class GestureController {
     const tap = new Tap(this.group, handleGesture.bind(this.messageHandler, 'click'), {
       applySmoothing: false,
     });
-    const swivel = new Swivel(this.group, this.processSwivel.bind(this), {
+    const swivel = new Swivel(this.group, this.handleSwivel.bind(this), {
       applySmoothing: false,
       enableKeys: ['ctrlKey'],
       dynamicPivot: true,
@@ -83,7 +83,7 @@ class GestureController {
    *
    * @param {string} event
    */
-  processSwivel(event) {
+  handleSwivel(event) {
     event.centroid = event.pivot;
     this.messageHandler.handleGesture('rotate', event);
   }

--- a/src/server/MessageHandler.js
+++ b/src/server/MessageHandler.js
@@ -60,29 +60,6 @@ class MessageHandler {
   }
 
   /**
-   * Apply a transformation event, splitting it into rotate, scale, and
-   * move.
-   *
-   * @param {object} event
-   * @param {object} data
-   */
-  transform(event, data) {
-    const { delta } = data;
-
-    if (Object.prototype.hasOwnProperty.call(delta, 'scale')) {
-      this.scale(event, delta);
-    }
-
-    if (Object.prototype.hasOwnProperty.call(delta, 'rotation')) {
-      this.rotate(event, delta);
-    }
-
-    if (Object.prototype.hasOwnProperty.call(delta, 'translation')) {
-      this.drag(event, delta);
-    }
-  }
-
-  /**
    * Apply a scale event
    *
    * @param {object} event

--- a/src/server/MessageHandler.js
+++ b/src/server/MessageHandler.js
@@ -39,7 +39,7 @@ class MessageHandler {
     if (target != null) {
       const original = device.reversePoint(centroid.x, centroid.y);
       const { x, y } = view.transformPoint(original.x, original.y);
-      this[gesture]({ device, group, view, target, x, y }, data);
+      this[gesture]({ ...event, centroid: { x, y }, x, y, target }, data);
     }
   }
 

--- a/src/server/ServerElement.js
+++ b/src/server/ServerElement.js
@@ -24,8 +24,6 @@ const { Hittable, Identifiable } = require('../mixins.js');
  *
  * @param {Namespace} namespace - Socket.io namespace for publishing changes.
  * @param {Object} values - User-supplied data detailing the elements.
- * Properties on this object that line up with {@link module:shared.Element}
- * members will be stored. Any other properties will be ignored.
  */
 class ServerElement extends Identifiable(Hittable(WamsElement)) {
   constructor(namespace, values = {}) {
@@ -66,19 +64,6 @@ class ServerElement extends Identifiable(Hittable(WamsElement)) {
   setAttributes(attributes) {
     this.attributes = Object.assign(this.attributes, attributes);
     this.namespace.emit(Message.SET_ATTRS, { id: this.id, attributes });
-  }
-
-  /**
-   * Serialize the element as a JSON object.
-   *
-   * @returns {Object} The element as a JSON object.
-   * @override
-   */
-  toJSON() {
-    return {
-      ...super.toJSON(),
-      attributes: this.attributes,
-    };
   }
 }
 

--- a/src/server/ServerImage.js
+++ b/src/server/ServerImage.js
@@ -23,9 +23,7 @@ const { Hittable, Identifiable } = require('../mixins.js');
  * @extends __ServerImage
  *
  * @param {Namespace} namespace - Socket.io namespace for publishing changes.
- * @param {Object} values - User-supplied data detailing the image. Properties
- * on this object that line up with {@link module:shared.Image} members will be
- * stored. Any other properties will be ignored.
+ * @param {Object} values - User-supplied data detailing the image.
  */
 class ServerImage extends Identifiable(Hittable(WamsImage)) {
   constructor(namespace, values = {}) {
@@ -54,19 +52,6 @@ class ServerImage extends Identifiable(Hittable(WamsImage)) {
   setImage(path) {
     this.src = path;
     this.namespace.emit(Message.SET_IMAGE, { id: this.id, src: path });
-  }
-
-  /**
-   * Serialize the image as a JSON object.
-   *
-   * @returns {Object} The image as a JSON object.
-   * @override
-   */
-  toJSON() {
-    return {
-      ...super.toJSON(),
-      src: this.src,
-    };
   }
 }
 

--- a/src/server/ServerItem.js
+++ b/src/server/ServerItem.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { EventEmitter } = require('node:events');
-const { Item, Message } = require('../shared.js');
+const { CanvasItem, Message } = require('../shared.js');
 const { Hittable, Identifiable } = require('../mixins.js');
 
 /**
@@ -19,15 +19,13 @@ const { Hittable, Identifiable } = require('../mixins.js');
  * around.
  *
  * @memberof module:server
- * @extends module:shared.Item
+ * @extends module:shared.CanvasItem
  * @extends __ServerItem
  *
  * @param {Namespace} namespace - Socket.io namespace for publishing changes.
- * @param {Object} values - User-supplied data detailing the item. Properties on
- * this object that line up with {@link module:shared.Item} members will be
- * stored. Any other properties will be ignored.
+ * @param {Object} values - User-supplied data detailing the item.
  */
-class ServerItem extends Identifiable(Hittable(Item)) {
+class ServerItem extends Identifiable(Hittable(CanvasItem)) {
   constructor(namespace, values = {}) {
     super(values);
 
@@ -37,13 +35,6 @@ class ServerItem extends Identifiable(Hittable(Item)) {
      * @type {Namespace}
      */
     this.namespace = namespace;
-
-    /**
-     * Sequence of canvas instructions to be run on the client
-     *
-     * @type {CanvasSequence}
-     */
-    this.sequence = values.sequence;
   }
 
   /*
@@ -62,19 +53,6 @@ class ServerItem extends Identifiable(Hittable(Item)) {
   setSequence(sequence) {
     this.sequence = sequence;
     this.namespace.emit(Message.SET_RENDER, { id: this.id, sequence });
-  }
-
-  /**
-   * Serialize the item as a JSON object.
-   *
-   * @returns {Object} The item as a JSON object.
-   * @override
-   */
-  toJSON() {
-    return {
-      ...super.toJSON(),
-      sequence: this.sequence,
-    };
   }
 }
 

--- a/src/server/ServerItem.js
+++ b/src/server/ServerItem.js
@@ -42,9 +42,8 @@ class ServerItem extends Identifiable(Hittable(Item)) {
      * Sequence of canvas instructions to be run on the client
      *
      * @type {CanvasSequence}
-     * @default undefined
      */
-    this.sequence = undefined;
+    this.sequence = values.sequence;
   }
 
   /*

--- a/src/server/WorkSpace.js
+++ b/src/server/WorkSpace.js
@@ -126,7 +126,7 @@ class WorkSpace {
   removeItem(item) {
     if (removeById(this.items, item)) {
       item.unlock();
-      this.namespace.emit(Message.RM_ITEM, item);
+      this.namespace.emit(Message.RM_ITEM, { id: item.id });
     }
   }
 

--- a/src/server/WorkSpace.js
+++ b/src/server/WorkSpace.js
@@ -158,13 +158,9 @@ class WorkSpace {
    */
   spawnElement(values = {}) {
     const item = new ServerElement(this.namespace, values);
-    // Notify subscribers immediately.
+    this.addItem(item);
     this.namespace.emit(Message.ADD_ELEMENT, item);
-    if (values.attributes) {
-      // Must be called _after_ the "ADD" message is emitted
-      item.setAttributes(values.attributes);
-    }
-    return this.addItem(item);
+    return item;
   }
 
   /**
@@ -176,13 +172,9 @@ class WorkSpace {
    */
   spawnImage(values = {}) {
     const item = new ServerImage(this.namespace, values);
-    // Notify subscribers immediately.
+    this.addItem(item);
     this.namespace.emit(Message.ADD_IMAGE, item);
-    if (values.src) {
-      // Must be called _after_ the "ADD" message is emitted
-      item.setImage(values.src);
-    }
-    return this.addItem(item);
+    return item;
   }
 
   /**
@@ -194,13 +186,9 @@ class WorkSpace {
    */
   spawnItem(values = {}) {
     const item = new ServerItem(this.namespace, values);
-    // Notify subscribers immediately.
+    this.addItem(item);
     this.namespace.emit(Message.ADD_ITEM, item);
-    if (values.sequence) {
-      // Must be called _after_ the "ADD" message is emitted
-      item.setSequence(values.sequence);
-    }
-    return this.addItem(item);
+    return item;
   }
 
   /**

--- a/src/server/WorkSpace.js
+++ b/src/server/WorkSpace.js
@@ -87,10 +87,12 @@ class WorkSpace {
   _canLock(item) {
     const eventNames = item.eventNames();
     return (
+      item.onclick ||
       item.ondrag ||
       item.onpinch ||
       item.onrotate ||
       item.onswipe ||
+      eventNames.includes('click') ||
       eventNames.includes('drag') ||
       eventNames.includes('pinch') ||
       eventNames.includes('rotate') ||

--- a/src/server/WorkSpace.js
+++ b/src/server/WorkSpace.js
@@ -85,19 +85,10 @@ class WorkSpace {
   }
 
   _canLock(item) {
-    const eventNames = item.eventNames();
-    return (
-      item.onclick ||
-      item.ondrag ||
-      item.onpinch ||
-      item.onrotate ||
-      item.onswipe ||
-      eventNames.includes('click') ||
-      eventNames.includes('drag') ||
-      eventNames.includes('pinch') ||
-      eventNames.includes('rotate') ||
-      eventNames.includes('swipe')
-    );
+    // Instead of choosing some arbitrary subset of events that allow locking,
+    // consider any item with any kind of event listeners as lockable. It's
+    // still automagical but less opinionated.
+    return item.eventNames().length > 0;
   }
 
   /**

--- a/src/shared/bases.js
+++ b/src/shared/bases.js
@@ -6,6 +6,7 @@
  *
  * @class Item
  * @memberof module:shared
+ * @param {Object} values - User-supplied data detailing the item.
  */
 class Item {
   constructor(values = {}) {
@@ -88,6 +89,46 @@ class Item {
   }
 }
 
+class CanvasItem extends Item {
+  constructor(values = {}) {
+    super({
+      /**
+       * @name sequence
+       * @type {CanvasSequence}
+       * @default undefined
+       * @memberof module:shared.CanvasItem
+       * @instance
+       */
+      sequence: undefined,
+
+      type: 'item',
+      ...values, // Assigns additional attributes to the object
+    });
+  }
+
+  /**
+   * Serialize the item as a JSON object.
+   *
+   * @returns {Object} The item as a JSON object.
+   * @override
+   */
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      sequence: this.sequence,
+    };
+  }
+}
+
+/**
+ * This RectangularItem class provides a common interface between the client and
+ * the server by which the RectangularItems can interact safely.
+ *
+ * @class RectangularItem
+ * @extends module:shared.Item
+ * @memberof module:shared
+ * @param {Object} values - User-supplied data detailing the item.
+ */
 class RectangularItem extends Item {
   constructor(values = {}) {
     super({
@@ -132,7 +173,9 @@ class RectangularItem extends Item {
  * server by which the elements interact safely.
  *
  * @class WamsElement
+ * @extends module:shared.RectangularItem
  * @memberof module:shared
+ * @param {Object} values - User-supplied data detailing the item.
  */
 class WamsElement extends RectangularItem {
   constructor(values = {}) {
@@ -148,6 +191,26 @@ class WamsElement extends RectangularItem {
        */
       tagname: 'div',
 
+      /**
+       * Additional attributes to set on the DOM element.
+       *
+       * @name attributes
+       * @type {object}
+       * @default {}
+       * @memberof module:shared.WamsElement
+       * @instance
+       * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes}
+       * @example
+       * {
+       *  class: 'my-class',
+       *  id: 'my-id',
+       *  style: 'background-color: red;',
+       *  ...
+       *  // Any other attribute you want to set on the element
+       * }
+       */
+      attributes: {},
+
       type: 'item/element',
       ...values, // Assigns additional attributes to the object
     });
@@ -160,6 +223,7 @@ class WamsElement extends RectangularItem {
     return {
       ...super.toJSON(),
       tagname: this.tagname,
+      attributes: this.attributes,
     };
   }
 }
@@ -169,14 +233,40 @@ class WamsElement extends RectangularItem {
  * server by which the images can interact safely.
  *
  * @class WamsImage
+ * @extends module:shared.RectangularItem
  * @memberof module:shared
+ * @param {Object} values - User-supplied data detailing the item.
  */
 class WamsImage extends RectangularItem {
   constructor(values = {}) {
     super({
+      /**
+       * Source of the image.
+       *
+       * @name src
+       * @type {string}
+       * @default ''
+       * @memberof module:shared.WamsImage
+       * @instance
+       */
+      src: '',
+
       type: 'item/image',
       ...values, // Assigns additional attributes to the object
     });
+  }
+
+  /**
+   * Serialize the image as a JSON object.
+   *
+   * @returns {Object} The image as a JSON object.
+   * @override
+   */
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      src: this.src,
+    };
   }
 }
 
@@ -186,6 +276,8 @@ class WamsImage extends RectangularItem {
  *
  * @class View
  * @memberof module:shared
+ * @extends module:shared.RectangularItem
+ * @param {Object} values - User-supplied data detailing the item.
  */
 class View extends RectangularItem {
   constructor(values = {}) {
@@ -222,6 +314,7 @@ class View extends RectangularItem {
 }
 
 module.exports = {
+  CanvasItem,
   Item,
   View,
   WamsElement,

--- a/src/shared/bases.js
+++ b/src/shared/bases.js
@@ -55,7 +55,7 @@ class Item {
        * @memberof module:shared.Item
        * @instance
        */
-      type: 'item/polygonal',
+      type: 'item',
 
       /**
        * Whether to raise item upon interaction or lock Z position instead.
@@ -109,7 +109,7 @@ class RectangularItem extends Item {
        */
       height: 300,
 
-      type: 'item/rectangular',
+      type: 'item',
       ...values, // Assigns additional attributes to the object
     });
   }

--- a/tests/server/ServerItem.test.js
+++ b/tests/server/ServerItem.test.js
@@ -17,7 +17,7 @@ describe('ServerItem', () => {
         y: 0,
         rotation: 0,
         scale: 1,
-        type: 'item/polygonal',
+        type: 'item',
         lockZ: false,
       });
     });
@@ -122,7 +122,7 @@ describe('ServerItem', () => {
           y: 59,
           rotation: 0,
           scale: 1,
-          type: 'item/polygonal',
+          type: 'item',
         });
       });
     });
@@ -159,7 +159,7 @@ describe('ServerItem', () => {
           y: 59,
           rotation: 0,
           scale: 1,
-          type: 'item/polygonal',
+          type: 'item',
         });
       });
       test('Has no effect if parameters left out', () => {
@@ -195,7 +195,7 @@ describe('ServerItem', () => {
           y: 9,
           rotation: 0,
           scale: 1,
-          type: 'item/polygonal',
+          type: 'item',
         });
       });
     });

--- a/tests/server/WorkSpace.test.js
+++ b/tests/server/WorkSpace.test.js
@@ -32,7 +32,7 @@ describe('WorkSpace', () => {
           y: 0,
           rotation: 0,
           scale: 1,
-          type: 'item/polygonal',
+          type: 'item',
           lockZ: false,
         });
       });


### PR DESCRIPTION
- Remove unused transform()
- Forward as much of the original event as possible
- Rename processSwivel -> handleSwivel
- Use type='item' since that's what the switch statement looks for
- An item is considered lockable if it has _any_ event listeners attached
- Shorten timeout before removing swipe tail
- Optimize adding items: don't require a second packet to set sequence etc
- Send a minimal packet when asking to remove an item
- Make more use of the shared bases
